### PR TITLE
build: Update GRPC version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'dgp_cli=dgp.cli:cli',
     ]},
     include_package_data=True,
-    setup_requires=['cython==0.29.10', 'grpcio==1.21.1', 'grpcio-tools==1.21.1'],
+    setup_requires=['cython==0.29.10', 'grpcio==1.41.0', 'grpcio-tools==1.41.0'],
     install_requires=requirements,
     zip_safe=False,
     python_requires='>=3.6',


### PR DESCRIPTION
The current version cannot be build on Apple Silicon. Can we update this?

Related upstream issue: https://github.com/grpc/grpc/issues/25082

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/23)
<!-- Reviewable:end -->
