### PR TITLE
feat: add datum_type to get_datum_data

### DIFF
--- a/dgp/datasets/synchronized_dataset.py
+++ b/dgp/datasets/synchronized_dataset.py
@@ -246,6 +246,9 @@ class _SynchronizedDataset(BaseDataset):
         # TODO: Implement data/annotation load-time transforms, `torchvision` style.
         if annotations:
             datum_data.update(annotations)
+
+        datum_data['datum_type'] = datum_type
+
         return datum_data
 
     def __getitem__(self, index):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -31,10 +31,18 @@ class TestDataset(unittest.TestCase):
             'extrinsics',
             'bounding_box_2d',
             'bounding_box_3d',
+            'datum_type',
         ])
         expected_lidar_fields = set([
-            'point_cloud', 'timestamp', 'datum_name', 'pose', 'extrinsics', 'bounding_box_2d', 'bounding_box_3d',
-            'extra_channels'
+            'point_cloud',
+            'timestamp',
+            'datum_name',
+            'pose',
+            'extrinsics',
+            'bounding_box_2d',
+            'bounding_box_3d',
+            'extra_channels',
+            'datum_type',
         ])
 
         # Iterate through labeled dataset and check expected fields
@@ -67,12 +75,27 @@ class TestDataset(unittest.TestCase):
     def test_labeled_synchronized_scene_dataset(self):
         """Test synchronized scene dataset"""
         expected_camera_fields = set([
-            'rgb', 'timestamp', 'datum_name', 'pose', 'intrinsics', 'extrinsics', 'bounding_box_2d', 'bounding_box_3d',
-            'depth'
+            'rgb',
+            'timestamp',
+            'datum_name',
+            'pose',
+            'intrinsics',
+            'extrinsics',
+            'bounding_box_2d',
+            'bounding_box_3d',
+            'depth',
+            'datum_type',
         ])
         expected_lidar_fields = set([
-            'point_cloud', 'timestamp', 'datum_name', 'pose', 'extrinsics', 'bounding_box_2d', 'bounding_box_3d',
-            'extra_channels'
+            'point_cloud',
+            'timestamp',
+            'datum_name',
+            'pose',
+            'extrinsics',
+            'bounding_box_2d',
+            'bounding_box_3d',
+            'extra_channels',
+            'datum_type',
         ])
         expected_metadata_fields = set([
             'scene_index', 'sample_index_in_scene', 'log_id', 'timestamp', 'scene_name', 'scene_description'


### PR DESCRIPTION
Adds a datum_type key to the datum data dictionary returned by synchronized scene dataset.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/40)
<!-- Reviewable:end -->
