### PR TITLE
schema: add KeyPoint3D, KeyLine3D, Polygon3D

### DIFF
--- a/dgp/proto/annotations.proto
+++ b/dgp/proto/annotations.proto
@@ -66,6 +66,15 @@ enum AnnotationType {
 
   // Agent behavior
   AGENT_BEHAVIOR = 14;             // agent_behavior
+
+  // 3D Key Point in sensor space
+  KEY_POINT_3D = 15;               // key_point_3d
+
+  // 3D Key Line in sensor space
+  KEY_LINE_3D = 16;                // key_line_3d
+
+  // 3D Polygon in sensor space
+  POLYGON_3D = 17;                 // polygon_3d
 }
 
 // 2D bounding box
@@ -213,6 +222,68 @@ message Polygon2DAnnotation{
   map<string, string> attributes = 3;
 }
 
+// 3D point.
+message KeyPoint3D {
+  // (x, y, z) point (in 3D carthesian coordinates).
+  double x = 1;
+  double y = 2;
+  double z = 3;
+}
+
+// 3D point annotation.
+message KeyPoint3DAnnotation {
+  // Class identifier (should be in [0, num_classes - 1])
+  uint32 class_id = 1;
+
+  // 3D point.
+  KeyPoint3D point = 2;
+
+  // An associative map stores arbitrary attributes, where the key is attribute name
+  // and the value is attribute value. Both key_type and value_type are string.
+  map<string, string> attributes = 3;
+
+  // An identifier key. Used to link with other annotations.
+  string key = 4;
+}
+
+// 3D line annotation.
+message KeyLine3DAnnotation{
+  // Class identifier (should be in [0, num_classes - 1])
+  uint32 class_id = 1;
+
+  // 3D line.
+  repeated KeyPoint3D vertices = 2;
+
+  // An associative map stores arbitrary attributes, where the key is attribute name
+  // and the value is attribute value. Both key_type and value_type are string.
+  map<string, string> attributes = 3;
+
+  // An identifier key. Used to link with other annotations.
+  string key = 4;
+}
+
+message PolygonPoint3D {
+  // (x, y, z) point (in 3D carthesian coordinates).
+  double x = 1;
+  double y = 2;
+  double z = 3;
+}
+
+// 3D polygon annotation.
+message Polygon3DAnnotation{
+  // Class identifier (should be in [0, num_classes - 1])
+  uint32 class_id = 1;
+
+  // 3D polygon.
+  // Points should be put into this field with counter-clockwise order.
+  repeated PolygonPoint3D vertices = 2;
+
+  // An associative map stores arbitrary attributes, where the key is attribute name
+  // and the value is attribute value. Both key_type and value_type are string.
+  map<string, string> attributes = 3;
+}
+
+
 // List of BoundingBox2DAnnotation
 message BoundingBox2DAnnotations {
   repeated BoundingBox2DAnnotation annotations = 1;
@@ -236,4 +307,19 @@ message KeyLine2DAnnotations {
 // List of Polygon2DAnnotation
 message Polygon2DAnnotations {
   repeated Polygon2DAnnotation annotations = 1;
+}
+
+// List of KeyPoint3DAnnotation
+message KeyPoint3DAnnotations {
+  repeated KeyPoint3DAnnotation annotations = 1;
+}
+
+// List of KeyLine3DAnnotation
+message KeyLine3DAnnotations {
+  repeated KeyLine3DAnnotation annotations = 1;
+}
+
+// List of Polygon3DAnnotation
+message Polygon3DAnnotations {
+  repeated Polygon3DAnnotation annotations = 1;
 }


### PR DESCRIPTION
While KeyPoint2D, KeyLine2D, Polygon2D allow for point/line geomtries on the image plane, we would like to store the the 3D equivalents in carthesian coordinates in sensor space.

