### PR TITLE
ci: trigger doc-gen workflow on master branch

### DIFF
--- a/.github/workflows/doc-gen.yml
+++ b/.github/workflows/doc-gen.yml
@@ -2,7 +2,7 @@ name: doc-gen
 on:
   push:
     branches:
-      - main
+      - 'master'
 jobs:
   run:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
- fix typo `main` -> `master`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/46)
<!-- Reviewable:end -->
