### PR TITLE
test: fix badge generation bug

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,8 +45,9 @@ jobs:
         git config --local user.name "github-actions[bot]"
         git add docs/coverage.svg
         git commit -m "test: update coverage.svg"
-        git reset --soft HEAD~2 &&
-        git commit
+        git reset --soft HEAD~2
+        # shellcheck disable=SC1083 # code is irrelevant because git needs this literal
+        git commit -m "$(git log --format=%B --reverse HEAD..HEAD@{1})"
     - name: Push code coverage badge
       if: ${{ steps.changed_files.outputs.files_changed == 'true' && github.event_name != 'pull_request'}}
       uses: ad-m/github-push-action@master


### PR DESCRIPTION
test: fix badge generation bug
We  manually add in the aut-commentor, since the remote git is not set to populate it by itself
Example: https://github.com/sshusainTRI/dgp/commit/46d41ffc3f839fe3e3419d16d85afe8394ba0e85
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/56)
<!-- Reviewable:end -->
