### PR TITLE
feat: restore deterministic scene cache environment var

### DIFF
--- a/dgp/datasets/base_dataset.py
+++ b/dgp/datasets/base_dataset.py
@@ -43,7 +43,9 @@ class SceneContainer:
     This class also provides functionality for reinjecting autolabeled scenes into other scenes.
     """
     random_str = ''.join([str(random.randint(0, 9)) for _ in range(5)])
-    cache_dir = os.path.join(DGP_CACHE_DIR, f'dgp_diskcache_{random_str}')
+    cache_suffix = os.environ.get('DGP_SCENE_CACHE_SUFFIX', random_str)
+    cache_dir = os.path.join(DGP_CACHE_DIR, f'dgp_diskcache_{cache_suffix}')
+    logging.debug(f'using {cache_dir} for dgp scene container disk cache')
     SCENE_CACHE = Cache(cache_dir)
 
     def __init__(


### PR DESCRIPTION
This adds a deterministic option for the scene cache which prevents some errors when using spawn instead of fork for multiprocessing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/68)
<!-- Reviewable:end -->
