### PR TITLE
feat: expose disk cache setting to synchronized and pd datasets

### DIFF
--- a/dgp/datasets/frame_dataset.py
+++ b/dgp/datasets/frame_dataset.py
@@ -197,6 +197,9 @@ class FrameSceneDataset(_FrameDataset):
         use_diskcache=True,
         skip_missing_data=False,
     ):
+        if not use_diskcache:
+            logging.warning('Instantiating a dataset with use_diskcache=False may exhaust memory with a large dataset.')
+
         # Extract all scenes from the scene dataset JSON for the appropriate split
         scenes = BaseDataset._extract_scenes_from_scene_dataset_json(
             scene_dataset_json,
@@ -262,6 +265,8 @@ class FrameScene(_FrameDataset):
         use_diskcache=True,
         skip_missing_data=False,
     ):
+        if not use_diskcache:
+            logging.warning('Instantiating a dataset with use_diskcache=False may exhaust memory with a large dataset.')
 
         # Extract a single scene from the scene JSON
         scene = BaseDataset._extract_scene_from_scene_json(

--- a/dgp/datasets/pd_dataset.py
+++ b/dgp/datasets/pd_dataset.py
@@ -77,8 +77,9 @@ class _ParallelDomainDataset(_SynchronizedDataset):
         If True, uses virtual camera datums. See dgp.datasets.pd_dataset.VIRTUAL_CAMERA_DATUM_NAMES for more details.
 
     accumulation_context: dict, default None
-        Dictionary of datum names containing a tuple of (backward_context, forward_context) for sensor accumulation. For example, 'accumulation_context={'lidar':(3,1)}
-        accumulates lidar points over the past three time steps and one forward step. Only valid for lidar and radar datums.
+        Dictionary of datum names containing a tuple of (backward_context, forward_context) for sensor accumulation.
+        For example, 'accumulation_context={'lidar':(3,1)} accumulates lidar points over the past three time steps and
+        one forward step. Only valid for lidar and radar datums.
 
     transform_accumulated_box_points: bool, default: False
         Flag to use cuboid pose and instance id to warp points when using lidar accumulation.
@@ -228,11 +229,6 @@ class _ParallelDomainDataset(_SynchronizedDataset):
 
 class ParallelDomainSceneDataset(_ParallelDomainDataset):
     """
-    Parameters
-    ----------
-    dataset_root: str
-        Optional path to dataset root folder. Useful if dataset scene json is not in the same directory as the rest of the data.
-
     Refer to SynchronizedSceneDataset for parameters.
     """
     def __init__(
@@ -251,7 +247,11 @@ class ParallelDomainSceneDataset(_ParallelDomainDataset):
         accumulation_context=None,
         dataset_root=None,
         transform_accumulated_box_points=False,
+        use_diskcache=True,
     ):
+        if not use_diskcache:
+            logging.warning('Instantiating a dataset with use_diskcache=False may exhaust memory with a large dataset.')
+
         # Extract all scenes from the scene dataset JSON for the appropriate split
         scenes = BaseDataset._extract_scenes_from_scene_dataset_json(
             scene_dataset_json,
@@ -260,6 +260,7 @@ class ParallelDomainSceneDataset(_ParallelDomainDataset):
             is_datums_synchronized=True,
             skip_missing_data=skip_missing_data,
             dataset_root=dataset_root,
+            use_diskcache=use_diskcache,
         )
 
         # Return SynchronizedDataset with scenes built from dataset.json
@@ -298,7 +299,10 @@ class ParallelDomainScene(_ParallelDomainDataset):
         skip_missing_data=False,
         accumulation_context=None,
         transform_accumulated_box_points=False,
+        use_diskcache=True,
     ):
+        if not use_diskcache:
+            logging.warning('Instantiating a dataset with use_diskcache=False may exhaust memory with a large dataset.')
 
         # Extract a single scene from the scene JSON
         scene = BaseDataset._extract_scene_from_scene_json(
@@ -306,6 +310,7 @@ class ParallelDomainScene(_ParallelDomainDataset):
             requested_autolabels,
             is_datums_synchronized=True,
             skip_missing_data=skip_missing_data,
+            use_diskcache=use_diskcache,
         )
 
         # Return SynchronizedDataset with scenes built from dataset.json

--- a/dgp/datasets/synchronized_dataset.py
+++ b/dgp/datasets/synchronized_dataset.py
@@ -378,8 +378,9 @@ class SynchronizedSceneDataset(_SynchronizedDataset):
         Forward context in frames [T+1, ..., T+forward]
 
     accumulation_context: dict, default None
-        Dictionary of datum names containing a tuple of (backward_context, forward_context) for sensor accumulation. For example, 'accumulation_context={'lidar':(3,1)}
-        accumulates lidar points over the past three time steps and one forward step. Only valid for lidar and radar datums.
+        Dictionary of datum names containing a tuple of (backward_context, forward_context) for sensor accumulation.
+        For example, 'accumulation_context={'lidar':(3,1)} accumulates lidar points over the past three time steps and
+        one forward step. Only valid for lidar and radar datums.
 
     generate_depth_from_datum: str, default: None
         Datum name of the point cloud. If is not None, then the depth map will be generated for the camera using
@@ -396,6 +397,10 @@ class SynchronizedSceneDataset(_SynchronizedDataset):
 
     transform_accumulated_box_points: bool, default: False
         Flag to use cuboid pose and instance id to warp points when using lidar accumulation.
+
+    use_diskcache: bool, default: True
+        If True, cache ScenePb2 object using diskcache. If False, save the object in memory.
+        NOTE: Setting use_diskcache to False would exhaust the memory if have a large number of scenes.
 
     Refer to _SynchronizedDataset for remaining parameters.
     """
@@ -414,7 +419,11 @@ class SynchronizedSceneDataset(_SynchronizedDataset):
         skip_missing_data=False,
         dataset_root=None,
         transform_accumulated_box_points=False,
+        use_diskcache=True,
     ):
+        if not use_diskcache:
+            logging.warning('Instantiating a dataset with use_diskcache=False may exhaust memory with a large dataset.')
+
         # Extract all scenes from the scene dataset JSON for the appropriate split
         scenes = BaseDataset._extract_scenes_from_scene_dataset_json(
             scene_dataset_json,
@@ -422,7 +431,8 @@ class SynchronizedSceneDataset(_SynchronizedDataset):
             requested_autolabels,
             is_datums_synchronized=True,
             skip_missing_data=skip_missing_data,
-            dataset_root=dataset_root
+            dataset_root=dataset_root,
+            use_diskcache=use_diskcache,
         )
 
         # Return SynchronizedDataset with scenes built from dataset.json
@@ -472,8 +482,9 @@ class SynchronizedScene(_SynchronizedDataset):
         Forward context in frames [T+1, ..., T+forward]
 
     accumulation_context: dict, default None
-        Dictionary of datum names containing a tuple of (backward_context, forward_context) for sensor accumulation. For example, 'accumulation_context={'lidar':(3,1)}
-        accumulates lidar points over the past three time steps and one forward step. Only valid for lidar and radar datums.
+        Dictionary of datum names containing a tuple of (backward_context, forward_context) for sensor accumulation.
+        For example, 'accumulation_context={'lidar':(3,1)} accumulates lidar points over the past three time steps and
+        one forward step. Only valid for lidar and radar datums.
 
     generate_depth_from_datum: str, default: None
         Datum name of the point cloud. If is not None, then the depth map will be generated for the camera using
@@ -484,6 +495,10 @@ class SynchronizedScene(_SynchronizedDataset):
 
     transform_accumulated_box_points: bool, default: False
         Flag to use cuboid pose and instance id to warp points when using lidar accumulation.
+
+    use_diskcache: bool, default: True
+        If True, cache ScenePb2 object using diskcache. If False, save the object in memory.
+        NOTE: Setting use_diskcache to False would exhaust the memory if have a large number of scenes.
 
     Refer to _SynchronizedDataset for remaining parameters.
     """
@@ -499,13 +514,17 @@ class SynchronizedScene(_SynchronizedDataset):
         generate_depth_from_datum=None,
         only_annotated_datums=False,
         transform_accumulated_box_points=False,
+        use_diskcache=True,
     ):
+        if not use_diskcache:
+            logging.warning('Instantiating a dataset with use_diskcache=False may exhaust memory with a large dataset.')
 
         # Extract a single scene from the scene JSON
         scene = BaseDataset._extract_scene_from_scene_json(
             scene_json,
             requested_autolabels,
             is_datums_synchronized=True,
+            use_diskcache=use_diskcache,
         )
 
         # Return SynchronizedDataset with scenes built from dataset.json

--- a/dgp/utils/colors.py
+++ b/dgp/utils/colors.py
@@ -90,7 +90,7 @@ def adjust_lightness(color, factor=1.0):
     Tuple[int]
         Adjusted RGB color.
     """
-    hls = cv2.cvtColor(np.uint8(color).reshape(1, 1, 3), cv2.COLOR_RGB2HLS).flatten()
+    hls = cv2.cvtColor(np.uint8(color).reshape(1, 1, 3), cv2.COLOR_RGB2HLS).flatten()  # pylint: disable=too-many-function-args
     adjusted_hls = [hls[0], int(max(0, min(255, hls[1] * factor))), hls[2]]
-    adjusted_rgb = cv2.cvtColor(np.uint8(adjusted_hls).reshape(1, 1, 3), cv2.COLOR_HLS2RGB).flatten()
+    adjusted_rgb = cv2.cvtColor(np.uint8(adjusted_hls).reshape(1, 1, 3), cv2.COLOR_HLS2RGB).flatten()  # pylint: disable=too-many-function-args
     return (int(adjusted_rgb[0]), int(adjusted_rgb[1]), int(adjusted_rgb[2]))


### PR DESCRIPTION
- This allows users to specify if they want to use the scene disk cache when memory is not a concern. 
- Also adds some minor format changes and silences a pylint warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/74)
<!-- Reviewable:end -->
