### PR TITLE
schema: add support for additional camera models in camera intrinsics

### DIFF
--- a/dgp/proto/geometry.proto
+++ b/dgp/proto/geometry.proto
@@ -40,4 +40,58 @@ message CameraIntrinsics {
   double cx = 3;
   double cy = 4;
   double skew = 5;
+
+  // Camera distortion parameters, copied over from Parallel Domain
+  // These include the default opencv distorition model parameters (Brown Conrady)
+  // See https://en.wikipedia.org/wiki/Distortion_(optics) and opencv calibrateCamera for details
+  // Additionally the Double Sphere Camera Model (https://arxiv.org/pdf/1807.08957.pdf) by Usenko, Demmel, and Cremers
+  // is an excellent reference
+  double fov = 6;
+  int32  fisheye = 7;
+  double k1 = 8;
+  double k2 = 9;
+  double k3 = 10;
+  double k4 = 11;
+  double k5 = 12;
+  double k6 = 13;
+  double p1 = 14;
+  double p2 = 15;
+
+  // Additional parameters for thin prism model
+  double s1 = 16;
+  double s2 = 17;
+  double s3 = 18;
+  double s4 = 19;
+
+  // Additional parameters for tilted sensor model
+  double taux = 20;
+  double tauy = 21;
+
+  // Additional parameters for UCM and EUCM camera models
+  double alpha = 22;
+  double beta = 23;
+
+  // Additional parameters for FOV camera model
+  double w = 24;
+
+  // Parameters for Double Sphere model
+  double xi = 25;
+
+  enum CameraModel {
+    UNDEFINED =0;
+    PINHOLE =1; // fx,fy,cx,cy,skew. No distortion parameters
+    BC = 2; // Brown Conrady, k1,k2,p1,p2,k3
+    RATIONAL = 3; // Same as above but adds k4,k5,k6
+    THIN_PRISM = 4; // Same as above but adds s1,s2,s3,s4
+    TILTED = 5; // Same as above but adds taux, tauy
+    UCM = 6; // unified camera model: only alpha
+    EUCM = 7; // extended unified camera model: alpha, beta
+    KB = 8; // Kannala Brandt: k1,k2,k3,k4
+    FOV = 9; // Field of View: w
+    DS = 10; // Double Sphere: alpha, xi
+    OTHER = 255;
+  }
+
+  CameraModel model = 26;
+
 }

--- a/dgp/proto/geometry.proto
+++ b/dgp/proto/geometry.proto
@@ -77,21 +77,4 @@ message CameraIntrinsics {
   // Parameters for Double Sphere model
   double xi = 25;
 
-  enum CameraModel {
-    UNDEFINED =0;
-    PINHOLE =1; // fx,fy,cx,cy,skew. No distortion parameters
-    BC = 2; // Brown Conrady, k1,k2,p1,p2,k3
-    RATIONAL = 3; // Same as above but adds k4,k5,k6
-    THIN_PRISM = 4; // Same as above but adds s1,s2,s3,s4
-    TILTED = 5; // Same as above but adds taux, tauy
-    UCM = 6; // unified camera model: only alpha
-    EUCM = 7; // extended unified camera model: alpha, beta
-    KB = 8; // Kannala Brandt: k1,k2,k3,k4
-    FOV = 9; // Field of View: w
-    DS = 10; // Double Sphere: alpha, xi
-    OTHER = 255;
-  }
-
-  CameraModel model = 26;
-
 }

--- a/dgp/proto/geometry_pb2.py
+++ b/dgp/proto/geometry_pb2.py
@@ -19,85 +19,10 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x18\x64gp/proto/geometry.proto\x12\tdgp.proto\"*\n\x07Point3D\x12\t\n\x01x\x18\x01 \x01(\x02\x12\t\n\x01y\x18\x02 \x01(\x02\x12\t\n\x01z\x18\x03 \x01(\x02\"*\n\x07Vector3\x12\t\n\x01x\x18\x01 \x01(\x01\x12\t\n\x01y\x18\x02 \x01(\x01\x12\t\n\x01z\x18\x03 \x01(\x01\"<\n\nQuaternion\x12\n\n\x02qx\x18\x01 \x01(\x01\x12\n\n\x02qy\x18\x02 \x01(\x01\x12\n\n\x02qz\x18\x03 \x01(\x01\x12\n\n\x02qw\x18\x04 \x01(\x01\"X\n\x04Pose\x12\'\n\x0btranslation\x18\x01 \x01(\x0b\x32\x12.dgp.proto.Vector3\x12\'\n\x08rotation\x18\x02 \x01(\x0b\x32\x15.dgp.proto.Quaternion\"\x9c\x04\n\x10\x43\x61meraIntrinsics\x12\n\n\x02\x66x\x18\x01 \x01(\x01\x12\n\n\x02\x66y\x18\x02 \x01(\x01\x12\n\n\x02\x63x\x18\x03 \x01(\x01\x12\n\n\x02\x63y\x18\x04 \x01(\x01\x12\x0c\n\x04skew\x18\x05 \x01(\x01\x12\x0b\n\x03\x66ov\x18\x06 \x01(\x01\x12\x0f\n\x07\x66isheye\x18\x07 \x01(\x05\x12\n\n\x02k1\x18\x08 \x01(\x01\x12\n\n\x02k2\x18\t \x01(\x01\x12\n\n\x02k3\x18\n \x01(\x01\x12\n\n\x02k4\x18\x0b \x01(\x01\x12\n\n\x02k5\x18\x0c \x01(\x01\x12\n\n\x02k6\x18\r \x01(\x01\x12\n\n\x02p1\x18\x0e \x01(\x01\x12\n\n\x02p2\x18\x0f \x01(\x01\x12\n\n\x02s1\x18\x10 \x01(\x01\x12\n\n\x02s2\x18\x11 \x01(\x01\x12\n\n\x02s3\x18\x12 \x01(\x01\x12\n\n\x02s4\x18\x13 \x01(\x01\x12\x0c\n\x04taux\x18\x14 \x01(\x01\x12\x0c\n\x04tauy\x18\x15 \x01(\x01\x12\r\n\x05\x61lpha\x18\x16 \x01(\x01\x12\x0c\n\x04\x62\x65ta\x18\x17 \x01(\x01\x12\t\n\x01w\x18\x18 \x01(\x01\x12\n\n\x02xi\x18\x19 \x01(\x01\x12\x36\n\x05model\x18\x1a \x01(\x0e\x32\'.dgp.proto.CameraIntrinsics.CameraModel\"\x93\x01\n\x0b\x43\x61meraModel\x12\r\n\tUNDEFINED\x10\x00\x12\x0b\n\x07PINHOLE\x10\x01\x12\x06\n\x02\x42\x43\x10\x02\x12\x0c\n\x08RATIONAL\x10\x03\x12\x0e\n\nTHIN_PRISM\x10\x04\x12\n\n\x06TILTED\x10\x05\x12\x07\n\x03UCM\x10\x06\x12\x08\n\x04\x45UCM\x10\x07\x12\x06\n\x02KB\x10\x08\x12\x07\n\x03\x46OV\x10\t\x12\x06\n\x02\x44S\x10\n\x12\n\n\x05OTHER\x10\xff\x01\x62\x06proto3'
+  serialized_pb=b'\n\x18\x64gp/proto/geometry.proto\x12\tdgp.proto\"*\n\x07Point3D\x12\t\n\x01x\x18\x01 \x01(\x02\x12\t\n\x01y\x18\x02 \x01(\x02\x12\t\n\x01z\x18\x03 \x01(\x02\"*\n\x07Vector3\x12\t\n\x01x\x18\x01 \x01(\x01\x12\t\n\x01y\x18\x02 \x01(\x01\x12\t\n\x01z\x18\x03 \x01(\x01\"<\n\nQuaternion\x12\n\n\x02qx\x18\x01 \x01(\x01\x12\n\n\x02qy\x18\x02 \x01(\x01\x12\n\n\x02qz\x18\x03 \x01(\x01\x12\n\n\x02qw\x18\x04 \x01(\x01\"X\n\x04Pose\x12\'\n\x0btranslation\x18\x01 \x01(\x0b\x32\x12.dgp.proto.Vector3\x12\'\n\x08rotation\x18\x02 \x01(\x0b\x32\x15.dgp.proto.Quaternion\"\xce\x02\n\x10\x43\x61meraIntrinsics\x12\n\n\x02\x66x\x18\x01 \x01(\x01\x12\n\n\x02\x66y\x18\x02 \x01(\x01\x12\n\n\x02\x63x\x18\x03 \x01(\x01\x12\n\n\x02\x63y\x18\x04 \x01(\x01\x12\x0c\n\x04skew\x18\x05 \x01(\x01\x12\x0b\n\x03\x66ov\x18\x06 \x01(\x01\x12\x0f\n\x07\x66isheye\x18\x07 \x01(\x05\x12\n\n\x02k1\x18\x08 \x01(\x01\x12\n\n\x02k2\x18\t \x01(\x01\x12\n\n\x02k3\x18\n \x01(\x01\x12\n\n\x02k4\x18\x0b \x01(\x01\x12\n\n\x02k5\x18\x0c \x01(\x01\x12\n\n\x02k6\x18\r \x01(\x01\x12\n\n\x02p1\x18\x0e \x01(\x01\x12\n\n\x02p2\x18\x0f \x01(\x01\x12\n\n\x02s1\x18\x10 \x01(\x01\x12\n\n\x02s2\x18\x11 \x01(\x01\x12\n\n\x02s3\x18\x12 \x01(\x01\x12\n\n\x02s4\x18\x13 \x01(\x01\x12\x0c\n\x04taux\x18\x14 \x01(\x01\x12\x0c\n\x04tauy\x18\x15 \x01(\x01\x12\r\n\x05\x61lpha\x18\x16 \x01(\x01\x12\x0c\n\x04\x62\x65ta\x18\x17 \x01(\x01\x12\t\n\x01w\x18\x18 \x01(\x01\x12\n\n\x02xi\x18\x19 \x01(\x01\x62\x06proto3'
 )
 
 
-
-_CAMERAINTRINSICS_CAMERAMODEL = _descriptor.EnumDescriptor(
-  name='CameraModel',
-  full_name='dgp.proto.CameraIntrinsics.CameraModel',
-  filename=None,
-  file=DESCRIPTOR,
-  create_key=_descriptor._internal_create_key,
-  values=[
-    _descriptor.EnumValueDescriptor(
-      name='UNDEFINED', index=0, number=0,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='PINHOLE', index=1, number=1,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='BC', index=2, number=2,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='RATIONAL', index=3, number=3,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='THIN_PRISM', index=4, number=4,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='TILTED', index=5, number=5,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='UCM', index=6, number=6,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='EUCM', index=7, number=7,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='KB', index=8, number=8,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='FOV', index=9, number=9,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='DS', index=10, number=10,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='OTHER', index=11, number=255,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-  ],
-  containing_type=None,
-  serialized_options=None,
-  serialized_start=673,
-  serialized_end=820,
-)
-_sym_db.RegisterEnumDescriptor(_CAMERAINTRINSICS_CAMERAMODEL)
 
 
 _POINT3D = _descriptor.Descriptor(
@@ -467,19 +392,11 @@ _CAMERAINTRINSICS = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='model', full_name='dgp.proto.CameraIntrinsics.model', index=25,
-      number=26, type=14, cpp_type=8, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
-    _CAMERAINTRINSICS_CAMERAMODEL,
   ],
   serialized_options=None,
   is_extendable=False,
@@ -488,13 +405,11 @@ _CAMERAINTRINSICS = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=280,
-  serialized_end=820,
+  serialized_end=614,
 )
 
 _POSE.fields_by_name['translation'].message_type = _VECTOR3
 _POSE.fields_by_name['rotation'].message_type = _QUATERNION
-_CAMERAINTRINSICS.fields_by_name['model'].enum_type = _CAMERAINTRINSICS_CAMERAMODEL
-_CAMERAINTRINSICS_CAMERAMODEL.containing_type = _CAMERAINTRINSICS
 DESCRIPTOR.message_types_by_name['Point3D'] = _POINT3D
 DESCRIPTOR.message_types_by_name['Vector3'] = _VECTOR3
 DESCRIPTOR.message_types_by_name['Quaternion'] = _QUATERNION

--- a/dgp/proto/geometry_pb2.py
+++ b/dgp/proto/geometry_pb2.py
@@ -19,10 +19,85 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x18\x64gp/proto/geometry.proto\x12\tdgp.proto\"*\n\x07Point3D\x12\t\n\x01x\x18\x01 \x01(\x02\x12\t\n\x01y\x18\x02 \x01(\x02\x12\t\n\x01z\x18\x03 \x01(\x02\"*\n\x07Vector3\x12\t\n\x01x\x18\x01 \x01(\x01\x12\t\n\x01y\x18\x02 \x01(\x01\x12\t\n\x01z\x18\x03 \x01(\x01\"<\n\nQuaternion\x12\n\n\x02qx\x18\x01 \x01(\x01\x12\n\n\x02qy\x18\x02 \x01(\x01\x12\n\n\x02qz\x18\x03 \x01(\x01\x12\n\n\x02qw\x18\x04 \x01(\x01\"X\n\x04Pose\x12\'\n\x0btranslation\x18\x01 \x01(\x0b\x32\x12.dgp.proto.Vector3\x12\'\n\x08rotation\x18\x02 \x01(\x0b\x32\x15.dgp.proto.Quaternion\"P\n\x10\x43\x61meraIntrinsics\x12\n\n\x02\x66x\x18\x01 \x01(\x01\x12\n\n\x02\x66y\x18\x02 \x01(\x01\x12\n\n\x02\x63x\x18\x03 \x01(\x01\x12\n\n\x02\x63y\x18\x04 \x01(\x01\x12\x0c\n\x04skew\x18\x05 \x01(\x01\x62\x06proto3'
+  serialized_pb=b'\n\x18\x64gp/proto/geometry.proto\x12\tdgp.proto\"*\n\x07Point3D\x12\t\n\x01x\x18\x01 \x01(\x02\x12\t\n\x01y\x18\x02 \x01(\x02\x12\t\n\x01z\x18\x03 \x01(\x02\"*\n\x07Vector3\x12\t\n\x01x\x18\x01 \x01(\x01\x12\t\n\x01y\x18\x02 \x01(\x01\x12\t\n\x01z\x18\x03 \x01(\x01\"<\n\nQuaternion\x12\n\n\x02qx\x18\x01 \x01(\x01\x12\n\n\x02qy\x18\x02 \x01(\x01\x12\n\n\x02qz\x18\x03 \x01(\x01\x12\n\n\x02qw\x18\x04 \x01(\x01\"X\n\x04Pose\x12\'\n\x0btranslation\x18\x01 \x01(\x0b\x32\x12.dgp.proto.Vector3\x12\'\n\x08rotation\x18\x02 \x01(\x0b\x32\x15.dgp.proto.Quaternion\"\x9c\x04\n\x10\x43\x61meraIntrinsics\x12\n\n\x02\x66x\x18\x01 \x01(\x01\x12\n\n\x02\x66y\x18\x02 \x01(\x01\x12\n\n\x02\x63x\x18\x03 \x01(\x01\x12\n\n\x02\x63y\x18\x04 \x01(\x01\x12\x0c\n\x04skew\x18\x05 \x01(\x01\x12\x0b\n\x03\x66ov\x18\x06 \x01(\x01\x12\x0f\n\x07\x66isheye\x18\x07 \x01(\x05\x12\n\n\x02k1\x18\x08 \x01(\x01\x12\n\n\x02k2\x18\t \x01(\x01\x12\n\n\x02k3\x18\n \x01(\x01\x12\n\n\x02k4\x18\x0b \x01(\x01\x12\n\n\x02k5\x18\x0c \x01(\x01\x12\n\n\x02k6\x18\r \x01(\x01\x12\n\n\x02p1\x18\x0e \x01(\x01\x12\n\n\x02p2\x18\x0f \x01(\x01\x12\n\n\x02s1\x18\x10 \x01(\x01\x12\n\n\x02s2\x18\x11 \x01(\x01\x12\n\n\x02s3\x18\x12 \x01(\x01\x12\n\n\x02s4\x18\x13 \x01(\x01\x12\x0c\n\x04taux\x18\x14 \x01(\x01\x12\x0c\n\x04tauy\x18\x15 \x01(\x01\x12\r\n\x05\x61lpha\x18\x16 \x01(\x01\x12\x0c\n\x04\x62\x65ta\x18\x17 \x01(\x01\x12\t\n\x01w\x18\x18 \x01(\x01\x12\n\n\x02xi\x18\x19 \x01(\x01\x12\x36\n\x05model\x18\x1a \x01(\x0e\x32\'.dgp.proto.CameraIntrinsics.CameraModel\"\x93\x01\n\x0b\x43\x61meraModel\x12\r\n\tUNDEFINED\x10\x00\x12\x0b\n\x07PINHOLE\x10\x01\x12\x06\n\x02\x42\x43\x10\x02\x12\x0c\n\x08RATIONAL\x10\x03\x12\x0e\n\nTHIN_PRISM\x10\x04\x12\n\n\x06TILTED\x10\x05\x12\x07\n\x03UCM\x10\x06\x12\x08\n\x04\x45UCM\x10\x07\x12\x06\n\x02KB\x10\x08\x12\x07\n\x03\x46OV\x10\t\x12\x06\n\x02\x44S\x10\n\x12\n\n\x05OTHER\x10\xff\x01\x62\x06proto3'
 )
 
 
+
+_CAMERAINTRINSICS_CAMERAMODEL = _descriptor.EnumDescriptor(
+  name='CameraModel',
+  full_name='dgp.proto.CameraIntrinsics.CameraModel',
+  filename=None,
+  file=DESCRIPTOR,
+  create_key=_descriptor._internal_create_key,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='UNDEFINED', index=0, number=0,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='PINHOLE', index=1, number=1,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='BC', index=2, number=2,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='RATIONAL', index=3, number=3,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='THIN_PRISM', index=4, number=4,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='TILTED', index=5, number=5,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='UCM', index=6, number=6,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='EUCM', index=7, number=7,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='KB', index=8, number=8,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='FOV', index=9, number=9,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='DS', index=10, number=10,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='OTHER', index=11, number=255,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=673,
+  serialized_end=820,
+)
+_sym_db.RegisterEnumDescriptor(_CAMERAINTRINSICS_CAMERAMODEL)
 
 
 _POINT3D = _descriptor.Descriptor(
@@ -252,11 +327,159 @@ _CAMERAINTRINSICS = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='fov', full_name='dgp.proto.CameraIntrinsics.fov', index=5,
+      number=6, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='fisheye', full_name='dgp.proto.CameraIntrinsics.fisheye', index=6,
+      number=7, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='k1', full_name='dgp.proto.CameraIntrinsics.k1', index=7,
+      number=8, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='k2', full_name='dgp.proto.CameraIntrinsics.k2', index=8,
+      number=9, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='k3', full_name='dgp.proto.CameraIntrinsics.k3', index=9,
+      number=10, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='k4', full_name='dgp.proto.CameraIntrinsics.k4', index=10,
+      number=11, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='k5', full_name='dgp.proto.CameraIntrinsics.k5', index=11,
+      number=12, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='k6', full_name='dgp.proto.CameraIntrinsics.k6', index=12,
+      number=13, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='p1', full_name='dgp.proto.CameraIntrinsics.p1', index=13,
+      number=14, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='p2', full_name='dgp.proto.CameraIntrinsics.p2', index=14,
+      number=15, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='s1', full_name='dgp.proto.CameraIntrinsics.s1', index=15,
+      number=16, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='s2', full_name='dgp.proto.CameraIntrinsics.s2', index=16,
+      number=17, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='s3', full_name='dgp.proto.CameraIntrinsics.s3', index=17,
+      number=18, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='s4', full_name='dgp.proto.CameraIntrinsics.s4', index=18,
+      number=19, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='taux', full_name='dgp.proto.CameraIntrinsics.taux', index=19,
+      number=20, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='tauy', full_name='dgp.proto.CameraIntrinsics.tauy', index=20,
+      number=21, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='alpha', full_name='dgp.proto.CameraIntrinsics.alpha', index=21,
+      number=22, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='beta', full_name='dgp.proto.CameraIntrinsics.beta', index=22,
+      number=23, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='w', full_name='dgp.proto.CameraIntrinsics.w', index=23,
+      number=24, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='xi', full_name='dgp.proto.CameraIntrinsics.xi', index=24,
+      number=25, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='model', full_name='dgp.proto.CameraIntrinsics.model', index=25,
+      number=26, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
+    _CAMERAINTRINSICS_CAMERAMODEL,
   ],
   serialized_options=None,
   is_extendable=False,
@@ -264,12 +487,14 @@ _CAMERAINTRINSICS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=279,
-  serialized_end=359,
+  serialized_start=280,
+  serialized_end=820,
 )
 
 _POSE.fields_by_name['translation'].message_type = _VECTOR3
 _POSE.fields_by_name['rotation'].message_type = _QUATERNION
+_CAMERAINTRINSICS.fields_by_name['model'].enum_type = _CAMERAINTRINSICS_CAMERAMODEL
+_CAMERAINTRINSICS_CAMERAMODEL.containing_type = _CAMERAINTRINSICS
 DESCRIPTOR.message_types_by_name['Point3D'] = _POINT3D
 DESCRIPTOR.message_types_by_name['Vector3'] = _VECTOR3
 DESCRIPTOR.message_types_by_name['Quaternion'] = _QUATERNION


### PR DESCRIPTION
This updates the camera intrinsics proto to include the changes made by PD: https://github.com/parallel-domain/dgp/blob/master/dgp/proto/geometry.proto#L30 
But also adds support for other camera distortion models such as the double sphere model.

Additional PRs will be needed for the dataloaders to use this information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/86)
<!-- Reviewable:end -->
