### PR TITLE
fix: allow end-uers to use more modern version of matplotlib dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ diskcache>=4.1.0
 grpcio==1.41.0
 grpcio-tools==1.41.0
 isort==4.3.21
-matplotlib==3.0.3
+matplotlib>=3.0.3,<4.0
 opencv-python==4.5.3.56
 Pillow>=8.3.2
 pycocotools>=2.0.0


### PR DESCRIPTION
`matplotlib` 3.0.1, currently required in `requirements.txt`, is not compatible with Python 3.8 which is the default python version for Ubuntu 20.0. Attempting installation will use the `platform` module and expect it has `linux_distribution`, but this has been moved to the `distro` module in modern Python.

I encountered this issue when installing DGP [in a venv](https://github.com/TRI-ML/dgp/blob/master/docs/VIRTUAL_ENV.md). Our framework in Woven uses Python 3.8.

Assuming Matplotlib respects semantic versioning, I expect these relaxed version requirements won't be a problem, but we ought to only allow different minor and patch versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/90)
<!-- Reviewable:end -->
