### PR TITLE
feat: allow for loading image datums without rgb

### DIFF
--- a/dgp/datasets/base_dataset.py
+++ b/dgp/datasets/base_dataset.py
@@ -806,7 +806,7 @@ class BaseDataset:
 
     requested_autolabels: tuple[str], default: None
         Tuple of annotation keys similar to `requested_annotations`, but associated with a particular autolabeling model.
-        Expected format is "<autolabel_model>/<annotation_key>"
+        Expected format is "<autolabel_model>/<annotation_key>".
 
     split: str, default: None
         Split of dataset to read ("train" | "val" | "test" | "train_overfit").
@@ -814,7 +814,11 @@ class BaseDataset:
         be used for unsupervised / self-supervised learning.
 
     autolabel_root: str, default: None
-       Optional path to autolabel root directory
+       Optional path to autolabel root directory.
+
+    load_image_rgb: bool, default: True
+        If set to false, raw image data will be skipped when loading and image datums will be returned having an 'rgb'
+        key set to None. This is useful when only annotations or extrinsics are needed.
     """
     def __init__(
         self,
@@ -825,6 +829,7 @@ class BaseDataset:
         requested_autolabels=None,
         split=None,
         autolabel_root=None,
+        load_image_rgb=True,
     ):
         logging.info(f'Instantiating dataset with {len(scenes)} scenes.')
         # Dataset metadata
@@ -885,6 +890,8 @@ class BaseDataset:
         self.autolabel_root = autolabel_root
         if self.autolabel_root is not None:
             self.autolabel_root = os.path.abspath(self.autolabel_root)
+
+        self.load_image_rgb = load_image_rgb
 
     @staticmethod
     def _extract_scenes_from_scene_dataset_json(
@@ -1664,7 +1671,10 @@ class BaseDataset:
             pose_WC_Tc = Pose()
 
         # Populate data for image data
-        image = self.load_datum(scene_idx, sample_idx_in_scene, datum_name)
+        image = None
+        if self.load_image_rgb:
+            image = self.load_datum(scene_idx, sample_idx_in_scene, datum_name)
+
         annotations = self.load_annotations(scene_idx, sample_idx_in_scene, datum_name)
         data = OrderedDict({
             "timestamp": datum.id.timestamp.ToMicroseconds(),

--- a/dgp/datasets/synchronized_dataset.py
+++ b/dgp/datasets/synchronized_dataset.py
@@ -63,6 +63,10 @@ class _SynchronizedDataset(BaseDataset):
 
     autolabel_root: str, default: None
         Path to autolabels.
+
+    load_image_rgb: bool, default: True
+        If set to false, raw image data will be skipped when loading and image datums will be returned having an 'rgb'
+        key set to None. This is useful when only annotations or extrinsics are needed.
     """
     def __init__(
         self,
@@ -78,6 +82,7 @@ class _SynchronizedDataset(BaseDataset):
         only_annotated_datums=False,
         transform_accumulated_box_points=False,
         autolabel_root=None,
+        load_image_rgb=True,
     ):
         self.set_context(backward=backward_context, forward=forward_context, accumulation_context=accumulation_context)
         self.generate_depth_from_datum = generate_depth_from_datum
@@ -91,6 +96,7 @@ class _SynchronizedDataset(BaseDataset):
             requested_annotations=requested_annotations,
             requested_autolabels=requested_autolabels,
             autolabel_root=autolabel_root,
+            load_image_rgb=load_image_rgb,
         )
 
     def _build_item_index(self):
@@ -416,6 +422,10 @@ class SynchronizedSceneDataset(_SynchronizedDataset):
         autolabel_root = '/some-autolabels' means the autolabel scene.json is found at
         /some-autolabels/<scene-dir>/autolabels/my-model/scene.json.
 
+    load_image_rgb: bool, default: True
+        If set to false, raw image data will be skipped when loading and image datums will be returned having an 'rgb'
+        key set to None. This is useful when only annotations or extrinsics are needed.
+
     Refer to _SynchronizedDataset for remaining parameters.
     """
     def __init__(
@@ -435,6 +445,7 @@ class SynchronizedSceneDataset(_SynchronizedDataset):
         transform_accumulated_box_points=False,
         use_diskcache=True,
         autolabel_root=None,
+        load_image_rgb=True,
     ):
         if not use_diskcache:
             logging.warning('Instantiating a dataset with use_diskcache=False may exhaust memory with a large dataset.')
@@ -468,6 +479,7 @@ class SynchronizedSceneDataset(_SynchronizedDataset):
             only_annotated_datums=only_annotated_datums,
             transform_accumulated_box_points=transform_accumulated_box_points,
             autolabel_root=autolabel_root,
+            load_image_rgb=load_image_rgb,
         )
 
 
@@ -524,6 +536,10 @@ class SynchronizedScene(_SynchronizedDataset):
         autolabel_root = '/some-autolabels' means the autolabel scene.json is found at
         /some-autolabels/<scene-dir>/autolabels/my-model/scene.json.
 
+    load_image_rgb: bool, default: True
+        If set to false, raw image data will be skipped when loading and image datums will be returned having an 'rgb'
+        key set to None. This is useful when only annotations or extrinsics are needed.
+
     Refer to _SynchronizedDataset for remaining parameters.
     """
     def __init__(
@@ -540,6 +556,7 @@ class SynchronizedScene(_SynchronizedDataset):
         transform_accumulated_box_points=False,
         use_diskcache=True,
         autolabel_root=None,
+        load_image_rgb=True,
     ):
         if not use_diskcache:
             logging.warning('Instantiating a dataset with use_diskcache=False may exhaust memory with a large dataset.')
@@ -573,4 +590,5 @@ class SynchronizedScene(_SynchronizedDataset):
             only_annotated_datums=only_annotated_datums,
             transform_accumulated_box_points=transform_accumulated_box_points,
             autolabel_root=autolabel_root,
+            load_image_rgb=load_image_rgb,
         )

--- a/dgp/datasets/synchronized_dataset.py
+++ b/dgp/datasets/synchronized_dataset.py
@@ -64,9 +64,11 @@ class _SynchronizedDataset(BaseDataset):
     autolabel_root: str, default: None
         Path to autolabels.
 
-    load_image_rgb: bool, default: True
-        If set to false, raw image data will be skipped when loading and image datums will be returned having an 'rgb'
-        key set to None. This is useful when only annotations or extrinsics are needed.
+    ignore_raw_datum: Optional[list[str]], default: None
+        Optionally pass a list of datum types to skip loading their raw data (but still load their annotations). For
+        example, ignore_raw_datum=['image'] will skip loading the image rgb data. The rgb key will be set to None.
+        This is useful when only annotations or extrinsics are needed. Allowed values are any combination of
+        'image','point_cloud','radar_point_cloud'    
     """
     def __init__(
         self,
@@ -82,7 +84,7 @@ class _SynchronizedDataset(BaseDataset):
         only_annotated_datums=False,
         transform_accumulated_box_points=False,
         autolabel_root=None,
-        load_image_rgb=True,
+        ignore_raw_datum=None,
     ):
         self.set_context(backward=backward_context, forward=forward_context, accumulation_context=accumulation_context)
         self.generate_depth_from_datum = generate_depth_from_datum
@@ -96,7 +98,7 @@ class _SynchronizedDataset(BaseDataset):
             requested_annotations=requested_annotations,
             requested_autolabels=requested_autolabels,
             autolabel_root=autolabel_root,
-            load_image_rgb=load_image_rgb,
+            ignore_raw_datum=ignore_raw_datum,
         )
 
     def _build_item_index(self):
@@ -422,9 +424,11 @@ class SynchronizedSceneDataset(_SynchronizedDataset):
         autolabel_root = '/some-autolabels' means the autolabel scene.json is found at
         /some-autolabels/<scene-dir>/autolabels/my-model/scene.json.
 
-    load_image_rgb: bool, default: True
-        If set to false, raw image data will be skipped when loading and image datums will be returned having an 'rgb'
-        key set to None. This is useful when only annotations or extrinsics are needed.
+    ignore_raw_datum: Optional[list[str]], default: None
+        Optionally pass a list of datum types to skip loading their raw data (but still load their annotations). For
+        example, ignore_raw_datum=['image'] will skip loading the image rgb data. The rgb key will be set to None.
+        This is useful when only annotations or extrinsics are needed. Allowed values are any combination of
+        'image','point_cloud','radar_point_cloud'
 
     Refer to _SynchronizedDataset for remaining parameters.
     """
@@ -445,7 +449,7 @@ class SynchronizedSceneDataset(_SynchronizedDataset):
         transform_accumulated_box_points=False,
         use_diskcache=True,
         autolabel_root=None,
-        load_image_rgb=True,
+        ignore_raw_datum=None,
     ):
         if not use_diskcache:
             logging.warning('Instantiating a dataset with use_diskcache=False may exhaust memory with a large dataset.')
@@ -479,7 +483,7 @@ class SynchronizedSceneDataset(_SynchronizedDataset):
             only_annotated_datums=only_annotated_datums,
             transform_accumulated_box_points=transform_accumulated_box_points,
             autolabel_root=autolabel_root,
-            load_image_rgb=load_image_rgb,
+            ignore_raw_datum=ignore_raw_datum,
         )
 
 
@@ -536,9 +540,11 @@ class SynchronizedScene(_SynchronizedDataset):
         autolabel_root = '/some-autolabels' means the autolabel scene.json is found at
         /some-autolabels/<scene-dir>/autolabels/my-model/scene.json.
 
-    load_image_rgb: bool, default: True
-        If set to false, raw image data will be skipped when loading and image datums will be returned having an 'rgb'
-        key set to None. This is useful when only annotations or extrinsics are needed.
+    ignore_raw_datum: Optional[list[str]], default: None
+        Optionally pass a list of datum types to skip loading their raw data (but still load their annotations). For
+        example, ignore_raw_datum=['image'] will skip loading the image rgb data. The rgb key will be set to None.
+        This is useful when only annotations or extrinsics are needed. Allowed values are any combination of
+        'image','point_cloud','radar_point_cloud'
 
     Refer to _SynchronizedDataset for remaining parameters.
     """
@@ -556,7 +562,7 @@ class SynchronizedScene(_SynchronizedDataset):
         transform_accumulated_box_points=False,
         use_diskcache=True,
         autolabel_root=None,
-        load_image_rgb=True,
+        ignore_raw_datum=None,
     ):
         if not use_diskcache:
             logging.warning('Instantiating a dataset with use_diskcache=False may exhaust memory with a large dataset.')
@@ -590,5 +596,5 @@ class SynchronizedScene(_SynchronizedDataset):
             only_annotated_datums=only_annotated_datums,
             transform_accumulated_box_points=transform_accumulated_box_points,
             autolabel_root=autolabel_root,
-            load_image_rgb=load_image_rgb,
+            ignore_raw_datum=ignore_raw_datum,
         )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -24,7 +24,16 @@ class TestDataset(unittest.TestCase):
     ])
 
     @staticmethod
-    def _test_labeled_dataset(dataset):
+    def _test_labeled_dataset(dataset, with_rgb=True):
+        """Test the dataset
+
+        Parameters
+        ----------
+        dataset: a dgp dataset
+        with_rgb: bool, default: True
+            Determines how we should test the output of datum['rgb']. If false, datum['rgb'] should be None
+
+        """
         expected_camera_fields = set([
             'rgb',
             'timestamp',
@@ -70,9 +79,12 @@ class TestDataset(unittest.TestCase):
                         assert_true(datum['extrinsics'].matrix.shape == (4, 4))
                         # Check image sizes for context frames
                         assert_true(set(datum.keys()) == expected_camera_fields)
-                        if im_size is None:
-                            im_size = datum['rgb'].size
-                        assert_true(datum['rgb'].size == im_size)
+                        if with_rgb:
+                            if im_size is None:
+                                im_size = datum['rgb'].size
+                            assert_true(datum['rgb'].size == im_size)
+                        else:
+                            assert datum['rgb'] is None
                     else:
                         raise RuntimeError('Unexpected datum_name {}'.format(datum['datum_name']))
 
@@ -170,6 +182,21 @@ class TestDataset(unittest.TestCase):
             requested_annotations=("bounding_box_2d", "bounding_box_3d")
         )
         TestDataset._test_labeled_dataset(dataset)
+
+    def test_synchronized_scene_without_rgb(self):
+        """Test a single synchronized scene with labels"""
+        scene_json = os.path.join(
+            self.DGP_TEST_DATASET_DIR, "test_scene/scene_01/scene_a8dc5ed1da0923563f85ea129f0e0a83e7fe1867.json"
+        )
+        dataset = SynchronizedScene(
+            scene_json,
+            datum_names=['LIDAR', 'CAMERA_01', 'CAMERA_05', 'CAMERA_06'],
+            forward_context=1,
+            backward_context=1,
+            requested_annotations=("bounding_box_2d", "bounding_box_3d"),
+            load_image_rgb=False,
+        )
+        TestDataset._test_labeled_dataset(dataset, with_rgb=False)
 
     def test_cached_synchronized_scene_dataset(self):
         """Test cached synchronized scene dataset"""


### PR DESCRIPTION
This adds a flag to base_dataset and synchronized scene to optionally skip loading the raw image data in a camera datum. The rgb key will contain a None value. The expected use case is when loading autolabels and the raw image data is not needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/93)
<!-- Reviewable:end -->
