### PR TITLE
build: split requirements into lib and dev

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,6 +37,7 @@ jobs:
         pip install cython==0.29.21 numpy==1.19.4
         sudo apt-get install jq
         pip install -r requirements.txt
+        pip install -r requirements-dev.txt
         pip install coverage-badge
     - name: Run tests and calculate coverage
       id: test-runner

--- a/.github/workflows/doc-gen.yml
+++ b/.github/workflows/doc-gen.yml
@@ -22,6 +22,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install cython==0.29.21 numpy==1.19.4
         pip install -r requirements.txt
+        pip install -r requirements-dev.txt
         pip install -r docs/requirements-doc.txt
         cd docs
         make html

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -30,6 +30,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install cython==0.29.21 numpy==1.19.4
           pip install -r requirements.txt
+          pip install -r requirements-dev.txt
       - name: Check python code formatting with YAPF
         # Documentation: https://github.com/AlexanderMelde/yapf-action
         uses: AlexanderMelde/yapf-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,10 @@ RUN pip install --no-cache-dir \
 # Install python dependencies
 ARG WORKSPACE=/home/dgp
 WORKDIR ${WORKSPACE}
-COPY requirements.txt /tmp/
+COPY requirements.txt requirements-dev.txt /tmp/
 RUN pip install --no-cache-dir cython==0.29.21 numpy==1.19.4
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements-dev.txt
 
 # Settings for S3
 RUN aws configure set default.s3.max_concurrent_requests 100 && \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,10 @@
+awscli
+coverage==6.0.2
+grpcio==1.41.0
+grpcio-tools==1.41.0
+isort >=5.0,<6.0
+pylint>=2.8.1
+pytest==6.2.5
+pytest-timeout==2.0.1
+ujson==5.2.0
+yapf==0.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,24 +1,14 @@
-awscli
 boto3
 botocore
 Click>=7.1.2
-coverage==6.0.2
 diskcache>=4.1.0
-grpcio==1.41.0
-grpcio-tools==1.41.0
-isort >=5.0,<6.0
 matplotlib>=3.0.3,<4.0
-opencv-python==4.5.3.56
+opencv-python>=4.5.3.56
 Pillow>=8.3.2
 pycocotools>=2.0.0
-pylint>=2.8.1
 pyquaternion==0.9.5
-pytest==6.2.5
-pytest-timeout==2.0.1
 torch>=1.8.1
 torchvision>=0.9.1
 tqdm>=4.29.1
 tenacity>=6.0.0
-ujson==5.2.0
 xarray==0.16.2
-yapf==0.31.0

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ __version__ = importlib.import_module('dgp').__version__
 with open('requirements.txt', encoding='utf-8') as f:
     requirements = f.read().splitlines()
 
+with open('requirements-dev.txt', encoding='utf-8') as f:
+    requirements_dev = f.read().splitlines()
+
 packages = find_packages(exclude=['tests'])
 setup(
     name="dgp",
@@ -54,6 +57,7 @@ setup(
     include_package_data=True,
     setup_requires=['cython==0.29.21', 'grpcio==1.41.0', 'grpcio-tools==1.41.0'],
     install_requires=requirements,
+    extras_require={'dev': requirements_dev},
     zip_safe=False,
     python_requires='>=3.6',
     cmdclass={


### PR DESCRIPTION
This commit splits requirements into dependencies for lib and ones for dev. It allows an external repository that would import dgp to install not all the dependencies but only lib dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/96)
<!-- Reviewable:end -->
