### PR TITLE
schema: add KeyPoint3D, KeyLine3D, Polygon3D

### DIFF
--- a/dgp/proto/annotations.proto
+++ b/dgp/proto/annotations.proto
@@ -70,6 +70,15 @@ enum AnnotationType {
   // Classification.
   // (i.e. imagenet classification label)
   CLASSIFICATION = 15;             // classification
+
+  // 3D Key Point in sensor space
+  KEY_POINT_3D = 16;               // key_point_3d
+
+  // 3D Key Line in sensor space
+  KEY_LINE_3D = 17;                // key_line_3d
+
+  // 3D Polygon in sensor space
+  POLYGON_3D = 18;                 // polygon_3d
 }
 
 // 2D bounding box
@@ -105,9 +114,9 @@ message BoundingBox2DAnnotation {
   // Instance identifier
   uint32 instance_id = 5;
 
-  // An associative map stores arbitrary attributes, where the key is attribute name
-  // and the value is attribute value. Both key_type and value_type are string.
-  // This can be used to stored `agent_behavior` states (i.e., parked car, pedestrian intent).
+  // A map of attribute names to their values.
+  // This can be used to stored `agent_behavior` states (i.e., parked car, 
+  // pedestrian intent).
   map<string, string> attributes = 6;
 }
 
@@ -115,7 +124,8 @@ message BoundingBox2DAnnotation {
 message BoundingBox3D {
   // 3D Bounding box. Produced by first constructing a box of dimensions
   // width, length, height centered at the origin, then rotating it by the
-  // specified quaternion and finally translating the box to the center coordinate.
+  // specified quaternion and finally translating the box to the center 
+  // coordinate.
 
   // 6DoF pose of bounding 3D.
   // (Translation is the center point of the box)
@@ -138,7 +148,8 @@ message BoundingBox3D {
 
 // 3D bounding box annotation.
 message BoundingBox3DAnnotation {
-  // Class identifier. Should be in range [0, num_classes - 1].
+  // Class identifier. Should be in range [0, num_classes - 1],
+  // where num_classes is the total number of classes in your ontology.
   uint32 class_id = 1;
 
   // 3D box.
@@ -148,8 +159,7 @@ message BoundingBox3DAnnotation {
   // This needs to be unique to a scene.
   uint32 instance_id = 3;
 
-  // An associative map stores arbitrary attributes, where the key is attribute name
-  // and the value is attribute value. Both key_type and value_type are string.
+  // A map of attribute names to their values.
   map<string, string> attributes = 4;
 
   // Number of LIDAR points in the Bounding Box
@@ -166,33 +176,38 @@ message KeyPoint2D {
 
 // 2D point annotation.
 message KeyPoint2DAnnotation {
-  // Class identifier (should be in [0, num_classes - 1])
+  // Class identifier (should be in [0, num_classes - 1]),
+  // where num_classes is the total number of classes in your ontology.
   uint32 class_id = 1;
 
   // 2D point.
   KeyPoint2D point = 2;
 
-  // An associative map stores arbitrary attributes, where the key is attribute name
-  // and the value is attribute value. Both key_type and value_type are string.
+  // A map of attribute names to their values.
   map<string, string> attributes = 3;
 
-  // An identifier key. Used to link with other annotations.
+  // An identifier key. Used to link with other annotations
+  // (example: BoundingBox2D) which specify this key in their
+  // instance to link to corresponding KeyPoint2DAnnotation.
   string key = 4;
 }
 
 // 2D line annotation.
 message KeyLine2DAnnotation{
-  // Class identifier (should be in [0, num_classes - 1])
+  // Class identifier (should be in [0, num_classes - 1]),
+  // where num_classes is the total number of classes in your ontology.
   uint32 class_id = 1;
 
   // 2D line.
   repeated KeyPoint2D vertices = 2;
 
-  // An associative map stores arbitrary attributes, where the key is attribute name
-  // and the value is attribute value. Both key_type and value_type are string.
+  // A map of attribute names to their values.
+  // Add only key/value pairs that are stored in a project document accessible
+  // to project contributors.
   map<string, string> attributes = 3;
 
-  // An identifier key. Used to link with other annotations.
+  // An identifier key. Used to link with other annotations, which specify
+  // this key in their instance to link to corresponding KeyLine2DAnnotation.
   string key = 4;
 }
 
@@ -207,29 +222,99 @@ message PolygonPoint2D {
 
 // 2D polygon annotation.
 message Polygon2DAnnotation{
-  // Class identifier (should be in [0, num_classes - 1])
+  // Class identifier (should be in [0, num_classes - 1]),
+  // where num_classes is the total number of classes in your ontology.
   uint32 class_id = 1;
 
   // 2D polygon.
   // Points should be put into this field with counter-clockwise order.
   repeated PolygonPoint2D vertices = 2;
 
-  // An associative map stores arbitrary attributes, where the key is attribute name
-  // and the value is attribute value. Both key_type and value_type are string.
+  // A map of attribute names to their values.
   map<string, string> attributes = 3;
 }
 
 // Classification annotation.
 message ClassificationAnnotation{
-  // Class identifier (should be in [0, num_classes - 1])
+  // Class identifier (should be in [0, num_classes - 1]),
+  // where num_classes is the total number of classes in your ontology.
   uint32 class_id = 1;
 
-  // An associative map stores arbitrary attributes, where the key is attribute name
-  // and the value is attribute value. Both key_type and value_type are string.
+  // A map of attribute names to their values.
   map<string, string> attributes = 2;
 }
 
-// List of BoundingBox2DAnnotation.
+// 3D point.
+message KeyPoint3D {
+  // (x, y, z) point (in 3D Cartesian coordinates).
+  float x = 1;
+  float y = 2;
+  float z = 3;
+}
+
+// 3D point annotation.
+message KeyPoint3DAnnotation {
+  // Class identifier (should be in [0, num_classes - 1]),
+  // where num_classes is the total number of classes in your ontology.
+  uint32 class_id = 1;
+
+  // 3D point.
+  KeyPoint3D point = 2;
+
+  // A map of attribute names to their values.
+  // Add only key/value pairs that are stored in a project document accessible
+  // to project contributors.
+  map<string, string> attributes = 3;
+
+  // An identifier key. Used to link with other annotations, which specify
+  // this key in their instance to link to corresponding KeyPoint3DAnnotation.
+  string key = 4;
+}
+
+// 3D line annotation.
+message KeyLine3DAnnotation{
+  // Class identifier (should be in [0, num_classes - 1]),
+  // where num_classes is the total number of classes in your ontology.
+  uint32 class_id = 1;
+
+  // 3D line.
+  repeated KeyPoint3D vertices = 2;
+
+  // A map of attribute names to their values.
+  // Add only key/value pairs that are stored in a project document accessible
+  // to project contributors.
+  map<string, string> attributes = 3;
+
+  // An identifier key. Used to link with other annotations, which specify
+  // this key in their instance to link to corresponding KeyLine3DAnnotation.
+  string key = 4;
+}
+
+message PolygonPoint3D {
+  // (x, y, z) point (in 3D Cartesian coordinates).
+  float x = 1;
+  float y = 2;
+  float z = 3;
+}
+
+// 3D polygon annotation.
+message Polygon3DAnnotation{
+  // Class identifier (should be in [0, num_classes - 1]),
+  // where num_classes is the total number of classes in your ontology.
+  uint32 class_id = 1;
+
+  // 3D polygon.
+  // Points should be put into this field with counter-clockwise order.
+  repeated PolygonPoint3D vertices = 2;
+
+  // A map of attribute names to their values.
+  // Add only key/value pairs that are stored in a project document accessible
+  // to project contributors.
+  map<string, string> attributes = 3;
+}
+
+
+// List of BoundingBox2DAnnotation
 message BoundingBox2DAnnotations {
   repeated BoundingBox2DAnnotation annotations = 1;
 }
@@ -257,4 +342,19 @@ message Polygon2DAnnotations {
 // List of ClassificationAnnotation.
 message ClassificationAnnotations {
   repeated ClassificationAnnotation annotations = 1;
+}
+
+// List of KeyPoint3DAnnotation.
+message KeyPoint3DAnnotations {
+  repeated KeyPoint3DAnnotation annotations = 1;
+}
+
+// List of KeyLine3DAnnotation.
+message KeyLine3DAnnotations {
+  repeated KeyLine3DAnnotation annotations = 1;
+}
+
+// List of Polygon3DAnnotation.
+message Polygon3DAnnotations {
+  repeated Polygon3DAnnotation annotations = 1;
 }

--- a/dgp/proto/annotations_pb2.py
+++ b/dgp/proto/annotations_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x1b\x64gp/proto/annotations.proto\x12\tdgp.proto\x1a\x18\x64gp/proto/geometry.proto\";\n\rBoundingBox2D\x12\t\n\x01x\x18\x01 \x01(\x05\x12\t\n\x01y\x18\x02 \x01(\x05\x12\t\n\x01w\x18\x03 \x01(\r\x12\t\n\x01h\x18\x04 \x01(\r\"\x81\x02\n\x17\x42oundingBox2DAnnotation\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\r\x12%\n\x03\x62ox\x18\x02 \x01(\x0b\x32\x18.dgp.proto.BoundingBox2D\x12\x0c\n\x04\x61rea\x18\x03 \x01(\r\x12\x0f\n\x07iscrowd\x18\x04 \x01(\x08\x12\x13\n\x0binstance_id\x18\x05 \x01(\r\x12\x46\n\nattributes\x18\x06 \x03(\x0b\x32\x32.dgp.proto.BoundingBox2DAnnotation.AttributesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x84\x01\n\rBoundingBox3D\x12\x1d\n\x04pose\x18\x01 \x01(\x0b\x32\x0f.dgp.proto.Pose\x12\r\n\x05width\x18\x02 \x01(\x01\x12\x0e\n\x06length\x18\x03 \x01(\x01\x12\x0e\n\x06height\x18\x04 \x01(\x01\x12\x11\n\tocclusion\x18\x05 \x01(\r\x12\x12\n\ntruncation\x18\x06 \x01(\x01\"\xf6\x01\n\x17\x42oundingBox3DAnnotation\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\r\x12%\n\x03\x62ox\x18\x02 \x01(\x0b\x32\x18.dgp.proto.BoundingBox3D\x12\x13\n\x0binstance_id\x18\x03 \x01(\r\x12\x46\n\nattributes\x18\x04 \x03(\x0b\x32\x32.dgp.proto.BoundingBox3DAnnotation.AttributesEntry\x12\x12\n\nnum_points\x18\x05 \x01(\r\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\"\n\nKeyPoint2D\x12\t\n\x01x\x18\x01 \x01(\x05\x12\t\n\x01y\x18\x02 \x01(\x05\"\xd3\x01\n\x14KeyPoint2DAnnotation\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\r\x12$\n\x05point\x18\x02 \x01(\x0b\x32\x15.dgp.proto.KeyPoint2D\x12\x43\n\nattributes\x18\x03 \x03(\x0b\x32/.dgp.proto.KeyPoint2DAnnotation.AttributesEntry\x12\x0b\n\x03key\x18\x04 \x01(\t\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xd4\x01\n\x13KeyLine2DAnnotation\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\r\x12\'\n\x08vertices\x18\x02 \x03(\x0b\x32\x15.dgp.proto.KeyPoint2D\x12\x42\n\nattributes\x18\x03 \x03(\x0b\x32..dgp.proto.KeyLine2DAnnotation.AttributesEntry\x12\x0b\n\x03key\x18\x04 \x01(\t\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"&\n\x0ePolygonPoint2D\x12\t\n\x01x\x18\x01 \x01(\x05\x12\t\n\x01y\x18\x02 \x01(\x05\"\xcb\x01\n\x13Polygon2DAnnotation\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\r\x12+\n\x08vertices\x18\x02 \x03(\x0b\x32\x19.dgp.proto.PolygonPoint2D\x12\x42\n\nattributes\x18\x03 \x03(\x0b\x32..dgp.proto.Polygon2DAnnotation.AttributesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xa8\x01\n\x18\x43lassificationAnnotation\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\r\x12G\n\nattributes\x18\x02 \x03(\x0b\x32\x33.dgp.proto.ClassificationAnnotation.AttributesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"S\n\x18\x42oundingBox2DAnnotations\x12\x37\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32\".dgp.proto.BoundingBox2DAnnotation\"S\n\x18\x42oundingBox3DAnnotations\x12\x37\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32\".dgp.proto.BoundingBox3DAnnotation\"M\n\x15KeyPoint2DAnnotations\x12\x34\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32\x1f.dgp.proto.KeyPoint2DAnnotation\"K\n\x14KeyLine2DAnnotations\x12\x33\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32\x1e.dgp.proto.KeyLine2DAnnotation\"K\n\x14Polygon2DAnnotations\x12\x33\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32\x1e.dgp.proto.Polygon2DAnnotation\"U\n\x19\x43lassificationAnnotations\x12\x38\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32#.dgp.proto.ClassificationAnnotation*\xf6\x02\n\x0e\x41nnotationType\x12\x13\n\x0f\x42OUNDING_BOX_2D\x10\x00\x12\x13\n\x0f\x42OUNDING_BOX_3D\x10\x01\x12\x1c\n\x18SEMANTIC_SEGMENTATION_2D\x10\x02\x12\x1c\n\x18SEMANTIC_SEGMENTATION_3D\x10\x03\x12\x1c\n\x18INSTANCE_SEGMENTATION_2D\x10\x04\x12\x1c\n\x18INSTANCE_SEGMENTATION_3D\x10\x05\x12\t\n\x05\x44\x45PTH\x10\x06\x12\x16\n\x12SURFACE_NORMALS_2D\x10\r\x12\x16\n\x12SURFACE_NORMALS_3D\x10\x07\x12\x15\n\x11MOTION_VECTORS_2D\x10\x08\x12\x15\n\x11MOTION_VECTORS_3D\x10\t\x12\x10\n\x0cKEY_POINT_2D\x10\n\x12\x0f\n\x0bKEY_LINE_2D\x10\x0b\x12\x0e\n\nPOLYGON_2D\x10\x0c\x12\x12\n\x0e\x41GENT_BEHAVIOR\x10\x0e\x12\x12\n\x0e\x43LASSIFICATION\x10\x0f\x62\x06proto3'
+  serialized_pb=b'\n\x1b\x64gp/proto/annotations.proto\x12\tdgp.proto\x1a\x18\x64gp/proto/geometry.proto\";\n\rBoundingBox2D\x12\t\n\x01x\x18\x01 \x01(\x05\x12\t\n\x01y\x18\x02 \x01(\x05\x12\t\n\x01w\x18\x03 \x01(\r\x12\t\n\x01h\x18\x04 \x01(\r\"\x81\x02\n\x17\x42oundingBox2DAnnotation\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\r\x12%\n\x03\x62ox\x18\x02 \x01(\x0b\x32\x18.dgp.proto.BoundingBox2D\x12\x0c\n\x04\x61rea\x18\x03 \x01(\r\x12\x0f\n\x07iscrowd\x18\x04 \x01(\x08\x12\x13\n\x0binstance_id\x18\x05 \x01(\r\x12\x46\n\nattributes\x18\x06 \x03(\x0b\x32\x32.dgp.proto.BoundingBox2DAnnotation.AttributesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x84\x01\n\rBoundingBox3D\x12\x1d\n\x04pose\x18\x01 \x01(\x0b\x32\x0f.dgp.proto.Pose\x12\r\n\x05width\x18\x02 \x01(\x01\x12\x0e\n\x06length\x18\x03 \x01(\x01\x12\x0e\n\x06height\x18\x04 \x01(\x01\x12\x11\n\tocclusion\x18\x05 \x01(\r\x12\x12\n\ntruncation\x18\x06 \x01(\x01\"\xf6\x01\n\x17\x42oundingBox3DAnnotation\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\r\x12%\n\x03\x62ox\x18\x02 \x01(\x0b\x32\x18.dgp.proto.BoundingBox3D\x12\x13\n\x0binstance_id\x18\x03 \x01(\r\x12\x46\n\nattributes\x18\x04 \x03(\x0b\x32\x32.dgp.proto.BoundingBox3DAnnotation.AttributesEntry\x12\x12\n\nnum_points\x18\x05 \x01(\r\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\"\n\nKeyPoint2D\x12\t\n\x01x\x18\x01 \x01(\x05\x12\t\n\x01y\x18\x02 \x01(\x05\"\xd3\x01\n\x14KeyPoint2DAnnotation\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\r\x12$\n\x05point\x18\x02 \x01(\x0b\x32\x15.dgp.proto.KeyPoint2D\x12\x43\n\nattributes\x18\x03 \x03(\x0b\x32/.dgp.proto.KeyPoint2DAnnotation.AttributesEntry\x12\x0b\n\x03key\x18\x04 \x01(\t\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xd4\x01\n\x13KeyLine2DAnnotation\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\r\x12\'\n\x08vertices\x18\x02 \x03(\x0b\x32\x15.dgp.proto.KeyPoint2D\x12\x42\n\nattributes\x18\x03 \x03(\x0b\x32..dgp.proto.KeyLine2DAnnotation.AttributesEntry\x12\x0b\n\x03key\x18\x04 \x01(\t\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"&\n\x0ePolygonPoint2D\x12\t\n\x01x\x18\x01 \x01(\x05\x12\t\n\x01y\x18\x02 \x01(\x05\"\xcb\x01\n\x13Polygon2DAnnotation\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\r\x12+\n\x08vertices\x18\x02 \x03(\x0b\x32\x19.dgp.proto.PolygonPoint2D\x12\x42\n\nattributes\x18\x03 \x03(\x0b\x32..dgp.proto.Polygon2DAnnotation.AttributesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xa8\x01\n\x18\x43lassificationAnnotation\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\r\x12G\n\nattributes\x18\x02 \x03(\x0b\x32\x33.dgp.proto.ClassificationAnnotation.AttributesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"-\n\nKeyPoint3D\x12\t\n\x01x\x18\x01 \x01(\x02\x12\t\n\x01y\x18\x02 \x01(\x02\x12\t\n\x01z\x18\x03 \x01(\x02\"\xd3\x01\n\x14KeyPoint3DAnnotation\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\r\x12$\n\x05point\x18\x02 \x01(\x0b\x32\x15.dgp.proto.KeyPoint3D\x12\x43\n\nattributes\x18\x03 \x03(\x0b\x32/.dgp.proto.KeyPoint3DAnnotation.AttributesEntry\x12\x0b\n\x03key\x18\x04 \x01(\t\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xd4\x01\n\x13KeyLine3DAnnotation\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\r\x12\'\n\x08vertices\x18\x02 \x03(\x0b\x32\x15.dgp.proto.KeyPoint3D\x12\x42\n\nattributes\x18\x03 \x03(\x0b\x32..dgp.proto.KeyLine3DAnnotation.AttributesEntry\x12\x0b\n\x03key\x18\x04 \x01(\t\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"1\n\x0ePolygonPoint3D\x12\t\n\x01x\x18\x01 \x01(\x02\x12\t\n\x01y\x18\x02 \x01(\x02\x12\t\n\x01z\x18\x03 \x01(\x02\"\xcb\x01\n\x13Polygon3DAnnotation\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\r\x12+\n\x08vertices\x18\x02 \x03(\x0b\x32\x19.dgp.proto.PolygonPoint3D\x12\x42\n\nattributes\x18\x03 \x03(\x0b\x32..dgp.proto.Polygon3DAnnotation.AttributesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"S\n\x18\x42oundingBox2DAnnotations\x12\x37\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32\".dgp.proto.BoundingBox2DAnnotation\"S\n\x18\x42oundingBox3DAnnotations\x12\x37\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32\".dgp.proto.BoundingBox3DAnnotation\"M\n\x15KeyPoint2DAnnotations\x12\x34\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32\x1f.dgp.proto.KeyPoint2DAnnotation\"K\n\x14KeyLine2DAnnotations\x12\x33\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32\x1e.dgp.proto.KeyLine2DAnnotation\"K\n\x14Polygon2DAnnotations\x12\x33\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32\x1e.dgp.proto.Polygon2DAnnotation\"U\n\x19\x43lassificationAnnotations\x12\x38\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32#.dgp.proto.ClassificationAnnotation\"M\n\x15KeyPoint3DAnnotations\x12\x34\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32\x1f.dgp.proto.KeyPoint3DAnnotation\"K\n\x14KeyLine3DAnnotations\x12\x33\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32\x1e.dgp.proto.KeyLine3DAnnotation\"K\n\x14Polygon3DAnnotations\x12\x33\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32\x1e.dgp.proto.Polygon3DAnnotation*\xa9\x03\n\x0e\x41nnotationType\x12\x13\n\x0f\x42OUNDING_BOX_2D\x10\x00\x12\x13\n\x0f\x42OUNDING_BOX_3D\x10\x01\x12\x1c\n\x18SEMANTIC_SEGMENTATION_2D\x10\x02\x12\x1c\n\x18SEMANTIC_SEGMENTATION_3D\x10\x03\x12\x1c\n\x18INSTANCE_SEGMENTATION_2D\x10\x04\x12\x1c\n\x18INSTANCE_SEGMENTATION_3D\x10\x05\x12\t\n\x05\x44\x45PTH\x10\x06\x12\x16\n\x12SURFACE_NORMALS_2D\x10\r\x12\x16\n\x12SURFACE_NORMALS_3D\x10\x07\x12\x15\n\x11MOTION_VECTORS_2D\x10\x08\x12\x15\n\x11MOTION_VECTORS_3D\x10\t\x12\x10\n\x0cKEY_POINT_2D\x10\n\x12\x0f\n\x0bKEY_LINE_2D\x10\x0b\x12\x0e\n\nPOLYGON_2D\x10\x0c\x12\x12\n\x0e\x41GENT_BEHAVIOR\x10\x0e\x12\x12\n\x0e\x43LASSIFICATION\x10\x0f\x12\x10\n\x0cKEY_POINT_3D\x10\x10\x12\x0f\n\x0bKEY_LINE_3D\x10\x11\x12\x0e\n\nPOLYGON_3D\x10\x12\x62\x06proto3'
   ,
   dependencies=[dgp_dot_proto_dot_geometry__pb2.DESCRIPTOR,])
 
@@ -112,11 +112,26 @@ _ANNOTATIONTYPE = _descriptor.EnumDescriptor(
       serialized_options=None,
       type=None,
       create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='KEY_POINT_3D', index=16, number=16,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='KEY_LINE_3D', index=17, number=17,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='POLYGON_3D', index=18, number=18,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2146,
-  serialized_end=2520,
+  serialized_start=3112,
+  serialized_end=3537,
 )
 _sym_db.RegisterEnumDescriptor(_ANNOTATIONTYPE)
 
@@ -137,6 +152,9 @@ KEY_LINE_2D = 11
 POLYGON_2D = 12
 AGENT_BEHAVIOR = 14
 CLASSIFICATION = 15
+KEY_POINT_3D = 16
+KEY_LINE_3D = 17
+POLYGON_3D = 18
 
 
 
@@ -884,6 +902,364 @@ _CLASSIFICATIONANNOTATION = _descriptor.Descriptor(
 )
 
 
+_KEYPOINT3D = _descriptor.Descriptor(
+  name='KeyPoint3D',
+  full_name='dgp.proto.KeyPoint3D',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='x', full_name='dgp.proto.KeyPoint3D.x', index=0,
+      number=1, type=2, cpp_type=6, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='y', full_name='dgp.proto.KeyPoint3D.y', index=1,
+      number=2, type=2, cpp_type=6, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='z', full_name='dgp.proto.KeyPoint3D.z', index=2,
+      number=3, type=2, cpp_type=6, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1655,
+  serialized_end=1700,
+)
+
+
+_KEYPOINT3DANNOTATION_ATTRIBUTESENTRY = _descriptor.Descriptor(
+  name='AttributesEntry',
+  full_name='dgp.proto.KeyPoint3DAnnotation.AttributesEntry',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='key', full_name='dgp.proto.KeyPoint3DAnnotation.AttributesEntry.key', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='dgp.proto.KeyPoint3DAnnotation.AttributesEntry.value', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=b'8\001',
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=338,
+  serialized_end=387,
+)
+
+_KEYPOINT3DANNOTATION = _descriptor.Descriptor(
+  name='KeyPoint3DAnnotation',
+  full_name='dgp.proto.KeyPoint3DAnnotation',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='class_id', full_name='dgp.proto.KeyPoint3DAnnotation.class_id', index=0,
+      number=1, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='point', full_name='dgp.proto.KeyPoint3DAnnotation.point', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='attributes', full_name='dgp.proto.KeyPoint3DAnnotation.attributes', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='key', full_name='dgp.proto.KeyPoint3DAnnotation.key', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[_KEYPOINT3DANNOTATION_ATTRIBUTESENTRY, ],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1703,
+  serialized_end=1914,
+)
+
+
+_KEYLINE3DANNOTATION_ATTRIBUTESENTRY = _descriptor.Descriptor(
+  name='AttributesEntry',
+  full_name='dgp.proto.KeyLine3DAnnotation.AttributesEntry',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='key', full_name='dgp.proto.KeyLine3DAnnotation.AttributesEntry.key', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='dgp.proto.KeyLine3DAnnotation.AttributesEntry.value', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=b'8\001',
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=338,
+  serialized_end=387,
+)
+
+_KEYLINE3DANNOTATION = _descriptor.Descriptor(
+  name='KeyLine3DAnnotation',
+  full_name='dgp.proto.KeyLine3DAnnotation',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='class_id', full_name='dgp.proto.KeyLine3DAnnotation.class_id', index=0,
+      number=1, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='vertices', full_name='dgp.proto.KeyLine3DAnnotation.vertices', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='attributes', full_name='dgp.proto.KeyLine3DAnnotation.attributes', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='key', full_name='dgp.proto.KeyLine3DAnnotation.key', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[_KEYLINE3DANNOTATION_ATTRIBUTESENTRY, ],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1917,
+  serialized_end=2129,
+)
+
+
+_POLYGONPOINT3D = _descriptor.Descriptor(
+  name='PolygonPoint3D',
+  full_name='dgp.proto.PolygonPoint3D',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='x', full_name='dgp.proto.PolygonPoint3D.x', index=0,
+      number=1, type=2, cpp_type=6, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='y', full_name='dgp.proto.PolygonPoint3D.y', index=1,
+      number=2, type=2, cpp_type=6, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='z', full_name='dgp.proto.PolygonPoint3D.z', index=2,
+      number=3, type=2, cpp_type=6, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2131,
+  serialized_end=2180,
+)
+
+
+_POLYGON3DANNOTATION_ATTRIBUTESENTRY = _descriptor.Descriptor(
+  name='AttributesEntry',
+  full_name='dgp.proto.Polygon3DAnnotation.AttributesEntry',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='key', full_name='dgp.proto.Polygon3DAnnotation.AttributesEntry.key', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='dgp.proto.Polygon3DAnnotation.AttributesEntry.value', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=b'8\001',
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=338,
+  serialized_end=387,
+)
+
+_POLYGON3DANNOTATION = _descriptor.Descriptor(
+  name='Polygon3DAnnotation',
+  full_name='dgp.proto.Polygon3DAnnotation',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='class_id', full_name='dgp.proto.Polygon3DAnnotation.class_id', index=0,
+      number=1, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='vertices', full_name='dgp.proto.Polygon3DAnnotation.vertices', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='attributes', full_name='dgp.proto.Polygon3DAnnotation.attributes', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[_POLYGON3DANNOTATION_ATTRIBUTESENTRY, ],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2183,
+  serialized_end=2386,
+)
+
+
 _BOUNDINGBOX2DANNOTATIONS = _descriptor.Descriptor(
   name='BoundingBox2DAnnotations',
   full_name='dgp.proto.BoundingBox2DAnnotations',
@@ -911,8 +1287,8 @@ _BOUNDINGBOX2DANNOTATIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1655,
-  serialized_end=1738,
+  serialized_start=2388,
+  serialized_end=2471,
 )
 
 
@@ -943,8 +1319,8 @@ _BOUNDINGBOX3DANNOTATIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1740,
-  serialized_end=1823,
+  serialized_start=2473,
+  serialized_end=2556,
 )
 
 
@@ -975,8 +1351,8 @@ _KEYPOINT2DANNOTATIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1825,
-  serialized_end=1902,
+  serialized_start=2558,
+  serialized_end=2635,
 )
 
 
@@ -1007,8 +1383,8 @@ _KEYLINE2DANNOTATIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1904,
-  serialized_end=1979,
+  serialized_start=2637,
+  serialized_end=2712,
 )
 
 
@@ -1039,8 +1415,8 @@ _POLYGON2DANNOTATIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1981,
-  serialized_end=2056,
+  serialized_start=2714,
+  serialized_end=2789,
 )
 
 
@@ -1071,8 +1447,104 @@ _CLASSIFICATIONANNOTATIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2058,
-  serialized_end=2143,
+  serialized_start=2791,
+  serialized_end=2876,
+)
+
+
+_KEYPOINT3DANNOTATIONS = _descriptor.Descriptor(
+  name='KeyPoint3DAnnotations',
+  full_name='dgp.proto.KeyPoint3DAnnotations',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='annotations', full_name='dgp.proto.KeyPoint3DAnnotations.annotations', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2878,
+  serialized_end=2955,
+)
+
+
+_KEYLINE3DANNOTATIONS = _descriptor.Descriptor(
+  name='KeyLine3DAnnotations',
+  full_name='dgp.proto.KeyLine3DAnnotations',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='annotations', full_name='dgp.proto.KeyLine3DAnnotations.annotations', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2957,
+  serialized_end=3032,
+)
+
+
+_POLYGON3DANNOTATIONS = _descriptor.Descriptor(
+  name='Polygon3DAnnotations',
+  full_name='dgp.proto.Polygon3DAnnotations',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='annotations', full_name='dgp.proto.Polygon3DAnnotations.annotations', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3034,
+  serialized_end=3109,
 )
 
 _BOUNDINGBOX2DANNOTATION_ATTRIBUTESENTRY.containing_type = _BOUNDINGBOX2DANNOTATION
@@ -1093,12 +1565,24 @@ _POLYGON2DANNOTATION.fields_by_name['vertices'].message_type = _POLYGONPOINT2D
 _POLYGON2DANNOTATION.fields_by_name['attributes'].message_type = _POLYGON2DANNOTATION_ATTRIBUTESENTRY
 _CLASSIFICATIONANNOTATION_ATTRIBUTESENTRY.containing_type = _CLASSIFICATIONANNOTATION
 _CLASSIFICATIONANNOTATION.fields_by_name['attributes'].message_type = _CLASSIFICATIONANNOTATION_ATTRIBUTESENTRY
+_KEYPOINT3DANNOTATION_ATTRIBUTESENTRY.containing_type = _KEYPOINT3DANNOTATION
+_KEYPOINT3DANNOTATION.fields_by_name['point'].message_type = _KEYPOINT3D
+_KEYPOINT3DANNOTATION.fields_by_name['attributes'].message_type = _KEYPOINT3DANNOTATION_ATTRIBUTESENTRY
+_KEYLINE3DANNOTATION_ATTRIBUTESENTRY.containing_type = _KEYLINE3DANNOTATION
+_KEYLINE3DANNOTATION.fields_by_name['vertices'].message_type = _KEYPOINT3D
+_KEYLINE3DANNOTATION.fields_by_name['attributes'].message_type = _KEYLINE3DANNOTATION_ATTRIBUTESENTRY
+_POLYGON3DANNOTATION_ATTRIBUTESENTRY.containing_type = _POLYGON3DANNOTATION
+_POLYGON3DANNOTATION.fields_by_name['vertices'].message_type = _POLYGONPOINT3D
+_POLYGON3DANNOTATION.fields_by_name['attributes'].message_type = _POLYGON3DANNOTATION_ATTRIBUTESENTRY
 _BOUNDINGBOX2DANNOTATIONS.fields_by_name['annotations'].message_type = _BOUNDINGBOX2DANNOTATION
 _BOUNDINGBOX3DANNOTATIONS.fields_by_name['annotations'].message_type = _BOUNDINGBOX3DANNOTATION
 _KEYPOINT2DANNOTATIONS.fields_by_name['annotations'].message_type = _KEYPOINT2DANNOTATION
 _KEYLINE2DANNOTATIONS.fields_by_name['annotations'].message_type = _KEYLINE2DANNOTATION
 _POLYGON2DANNOTATIONS.fields_by_name['annotations'].message_type = _POLYGON2DANNOTATION
 _CLASSIFICATIONANNOTATIONS.fields_by_name['annotations'].message_type = _CLASSIFICATIONANNOTATION
+_KEYPOINT3DANNOTATIONS.fields_by_name['annotations'].message_type = _KEYPOINT3DANNOTATION
+_KEYLINE3DANNOTATIONS.fields_by_name['annotations'].message_type = _KEYLINE3DANNOTATION
+_POLYGON3DANNOTATIONS.fields_by_name['annotations'].message_type = _POLYGON3DANNOTATION
 DESCRIPTOR.message_types_by_name['BoundingBox2D'] = _BOUNDINGBOX2D
 DESCRIPTOR.message_types_by_name['BoundingBox2DAnnotation'] = _BOUNDINGBOX2DANNOTATION
 DESCRIPTOR.message_types_by_name['BoundingBox3D'] = _BOUNDINGBOX3D
@@ -1109,12 +1593,20 @@ DESCRIPTOR.message_types_by_name['KeyLine2DAnnotation'] = _KEYLINE2DANNOTATION
 DESCRIPTOR.message_types_by_name['PolygonPoint2D'] = _POLYGONPOINT2D
 DESCRIPTOR.message_types_by_name['Polygon2DAnnotation'] = _POLYGON2DANNOTATION
 DESCRIPTOR.message_types_by_name['ClassificationAnnotation'] = _CLASSIFICATIONANNOTATION
+DESCRIPTOR.message_types_by_name['KeyPoint3D'] = _KEYPOINT3D
+DESCRIPTOR.message_types_by_name['KeyPoint3DAnnotation'] = _KEYPOINT3DANNOTATION
+DESCRIPTOR.message_types_by_name['KeyLine3DAnnotation'] = _KEYLINE3DANNOTATION
+DESCRIPTOR.message_types_by_name['PolygonPoint3D'] = _POLYGONPOINT3D
+DESCRIPTOR.message_types_by_name['Polygon3DAnnotation'] = _POLYGON3DANNOTATION
 DESCRIPTOR.message_types_by_name['BoundingBox2DAnnotations'] = _BOUNDINGBOX2DANNOTATIONS
 DESCRIPTOR.message_types_by_name['BoundingBox3DAnnotations'] = _BOUNDINGBOX3DANNOTATIONS
 DESCRIPTOR.message_types_by_name['KeyPoint2DAnnotations'] = _KEYPOINT2DANNOTATIONS
 DESCRIPTOR.message_types_by_name['KeyLine2DAnnotations'] = _KEYLINE2DANNOTATIONS
 DESCRIPTOR.message_types_by_name['Polygon2DAnnotations'] = _POLYGON2DANNOTATIONS
 DESCRIPTOR.message_types_by_name['ClassificationAnnotations'] = _CLASSIFICATIONANNOTATIONS
+DESCRIPTOR.message_types_by_name['KeyPoint3DAnnotations'] = _KEYPOINT3DANNOTATIONS
+DESCRIPTOR.message_types_by_name['KeyLine3DAnnotations'] = _KEYLINE3DANNOTATIONS
+DESCRIPTOR.message_types_by_name['Polygon3DAnnotations'] = _POLYGON3DANNOTATIONS
 DESCRIPTOR.enum_types_by_name['AnnotationType'] = _ANNOTATIONTYPE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -1236,6 +1728,65 @@ ClassificationAnnotation = _reflection.GeneratedProtocolMessageType('Classificat
 _sym_db.RegisterMessage(ClassificationAnnotation)
 _sym_db.RegisterMessage(ClassificationAnnotation.AttributesEntry)
 
+KeyPoint3D = _reflection.GeneratedProtocolMessageType('KeyPoint3D', (_message.Message,), {
+  'DESCRIPTOR' : _KEYPOINT3D,
+  '__module__' : 'dgp.proto.annotations_pb2'
+  # @@protoc_insertion_point(class_scope:dgp.proto.KeyPoint3D)
+  })
+_sym_db.RegisterMessage(KeyPoint3D)
+
+KeyPoint3DAnnotation = _reflection.GeneratedProtocolMessageType('KeyPoint3DAnnotation', (_message.Message,), {
+
+  'AttributesEntry' : _reflection.GeneratedProtocolMessageType('AttributesEntry', (_message.Message,), {
+    'DESCRIPTOR' : _KEYPOINT3DANNOTATION_ATTRIBUTESENTRY,
+    '__module__' : 'dgp.proto.annotations_pb2'
+    # @@protoc_insertion_point(class_scope:dgp.proto.KeyPoint3DAnnotation.AttributesEntry)
+    })
+  ,
+  'DESCRIPTOR' : _KEYPOINT3DANNOTATION,
+  '__module__' : 'dgp.proto.annotations_pb2'
+  # @@protoc_insertion_point(class_scope:dgp.proto.KeyPoint3DAnnotation)
+  })
+_sym_db.RegisterMessage(KeyPoint3DAnnotation)
+_sym_db.RegisterMessage(KeyPoint3DAnnotation.AttributesEntry)
+
+KeyLine3DAnnotation = _reflection.GeneratedProtocolMessageType('KeyLine3DAnnotation', (_message.Message,), {
+
+  'AttributesEntry' : _reflection.GeneratedProtocolMessageType('AttributesEntry', (_message.Message,), {
+    'DESCRIPTOR' : _KEYLINE3DANNOTATION_ATTRIBUTESENTRY,
+    '__module__' : 'dgp.proto.annotations_pb2'
+    # @@protoc_insertion_point(class_scope:dgp.proto.KeyLine3DAnnotation.AttributesEntry)
+    })
+  ,
+  'DESCRIPTOR' : _KEYLINE3DANNOTATION,
+  '__module__' : 'dgp.proto.annotations_pb2'
+  # @@protoc_insertion_point(class_scope:dgp.proto.KeyLine3DAnnotation)
+  })
+_sym_db.RegisterMessage(KeyLine3DAnnotation)
+_sym_db.RegisterMessage(KeyLine3DAnnotation.AttributesEntry)
+
+PolygonPoint3D = _reflection.GeneratedProtocolMessageType('PolygonPoint3D', (_message.Message,), {
+  'DESCRIPTOR' : _POLYGONPOINT3D,
+  '__module__' : 'dgp.proto.annotations_pb2'
+  # @@protoc_insertion_point(class_scope:dgp.proto.PolygonPoint3D)
+  })
+_sym_db.RegisterMessage(PolygonPoint3D)
+
+Polygon3DAnnotation = _reflection.GeneratedProtocolMessageType('Polygon3DAnnotation', (_message.Message,), {
+
+  'AttributesEntry' : _reflection.GeneratedProtocolMessageType('AttributesEntry', (_message.Message,), {
+    'DESCRIPTOR' : _POLYGON3DANNOTATION_ATTRIBUTESENTRY,
+    '__module__' : 'dgp.proto.annotations_pb2'
+    # @@protoc_insertion_point(class_scope:dgp.proto.Polygon3DAnnotation.AttributesEntry)
+    })
+  ,
+  'DESCRIPTOR' : _POLYGON3DANNOTATION,
+  '__module__' : 'dgp.proto.annotations_pb2'
+  # @@protoc_insertion_point(class_scope:dgp.proto.Polygon3DAnnotation)
+  })
+_sym_db.RegisterMessage(Polygon3DAnnotation)
+_sym_db.RegisterMessage(Polygon3DAnnotation.AttributesEntry)
+
 BoundingBox2DAnnotations = _reflection.GeneratedProtocolMessageType('BoundingBox2DAnnotations', (_message.Message,), {
   'DESCRIPTOR' : _BOUNDINGBOX2DANNOTATIONS,
   '__module__' : 'dgp.proto.annotations_pb2'
@@ -1278,6 +1829,27 @@ ClassificationAnnotations = _reflection.GeneratedProtocolMessageType('Classifica
   })
 _sym_db.RegisterMessage(ClassificationAnnotations)
 
+KeyPoint3DAnnotations = _reflection.GeneratedProtocolMessageType('KeyPoint3DAnnotations', (_message.Message,), {
+  'DESCRIPTOR' : _KEYPOINT3DANNOTATIONS,
+  '__module__' : 'dgp.proto.annotations_pb2'
+  # @@protoc_insertion_point(class_scope:dgp.proto.KeyPoint3DAnnotations)
+  })
+_sym_db.RegisterMessage(KeyPoint3DAnnotations)
+
+KeyLine3DAnnotations = _reflection.GeneratedProtocolMessageType('KeyLine3DAnnotations', (_message.Message,), {
+  'DESCRIPTOR' : _KEYLINE3DANNOTATIONS,
+  '__module__' : 'dgp.proto.annotations_pb2'
+  # @@protoc_insertion_point(class_scope:dgp.proto.KeyLine3DAnnotations)
+  })
+_sym_db.RegisterMessage(KeyLine3DAnnotations)
+
+Polygon3DAnnotations = _reflection.GeneratedProtocolMessageType('Polygon3DAnnotations', (_message.Message,), {
+  'DESCRIPTOR' : _POLYGON3DANNOTATIONS,
+  '__module__' : 'dgp.proto.annotations_pb2'
+  # @@protoc_insertion_point(class_scope:dgp.proto.Polygon3DAnnotations)
+  })
+_sym_db.RegisterMessage(Polygon3DAnnotations)
+
 
 _BOUNDINGBOX2DANNOTATION_ATTRIBUTESENTRY._options = None
 _BOUNDINGBOX3DANNOTATION_ATTRIBUTESENTRY._options = None
@@ -1285,4 +1857,7 @@ _KEYPOINT2DANNOTATION_ATTRIBUTESENTRY._options = None
 _KEYLINE2DANNOTATION_ATTRIBUTESENTRY._options = None
 _POLYGON2DANNOTATION_ATTRIBUTESENTRY._options = None
 _CLASSIFICATIONANNOTATION_ATTRIBUTESENTRY._options = None
+_KEYPOINT3DANNOTATION_ATTRIBUTESENTRY._options = None
+_KEYLINE3DANNOTATION_ATTRIBUTESENTRY._options = None
+_POLYGON3DANNOTATION_ATTRIBUTESENTRY._options = None
 # @@protoc_insertion_point(module_scope)


### PR DESCRIPTION
- add 3D equivalents in Cartesian coordinates in sensor space for KeyPoint2D,
KeyLine2D and Polygon2D on the image plane respectively.


This PR is based on Nisse's PR https://github.com/TRI-ML/dgp/pull/45
I don't have write access to the aformentioned PR so I opened a new PR with the changes asked by Quincy, after clarifications from Nisse.

Sorry for the incovenience @tk-woven ; let's continue discussion on this  PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/101)
<!-- Reviewable:end -->
