### PR TITLE
docs: add instructions for protos contribution

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -76,7 +76,8 @@ schema: add map schema
 - modify dgp.proto.dataset to hold map message
 ```
 
-**NOTE:** Any [proto schema](../dgp/proto) changes must be seperated from code changes into an independent commit and PR.
+**NOTE:** For adding any new [proto schema](../dgp/proto), please run `make build-proto` and also commit the compiled protos. Further, these [proto schema](../dgp/proto) and their compiled protos must be separated from code changes into one independent commit and PR.
+
 
 ### Pre-commit / Pre-push
 


### PR DESCRIPTION
Clarify an important workflow in `CONTRIBUTING.md` to avoid users adding compiled protos through their own workflows.
Example: related [PR](https://github.com/TRI-ML/dgp/pull/102) with above issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/103)
<!-- Reviewable:end -->
