### PR TITLE
fix: fix base image name in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.1-devel-ubuntu18.04
+FROM nvidia/cuda:11.1.1-devel-ubuntu18.04
 
 ARG python=3.7
 ENV PYTORCH_VERSION=1.8.1+cu111


### PR DESCRIPTION
# Description

11.1-devel-ubuntu18.04 is no longer available, so we use 11.1.1-devel-ubuntu18.04 in our Dockerfile.

This addresses #106 .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/107)
<!-- Reviewable:end -->
