### PR TITLE
fix: symlink python3, not python, to python3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,9 @@ RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-
   python${PYTHON_VERSION} \
   python${PYTHON_VERSION}-dev \
   && rm -rf /var/lib/apt/lists/*
-RUN ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python
+RUN ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python3
 RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
-  python get-pip.py && \
+  python3 get-pip.py && \
   rm get-pip.py
 
 # Install Pytorch


### PR DESCRIPTION
# Description

This addresses #105 . For Ubuntu 18, default python is 2.7 and python3 is 3.x, so we need to symlink `python3` and not `python`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/108)
<!-- Reviewable:end -->
