### PR TITLE
fix: explicitly load docparams pylint plugin in .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,7 @@
 # Copyright 2019-2020 Toyota Research Institute.  All rights reserved.
+[MAIN]
+load-plugins=pylint.extensions.docparams
+
 [MASTER]
 accept-no-param-doc=no
 accept-no-return-doc=yes


### PR DESCRIPTION
# Description

This is toward unblocking #101 which is stuck on a pylint configuration issue. We provide some configuration in `.pylintrc` that seems to expect the `check_docs` plugin, but the new plugin is `docparams`. We therefore explicitly load the `docparams` plugin when running pylint.

# Reproduction

Before this change, run

```
pylint setup.py
```

in the root of the repo, and you'll see

```
root@hostname:/home/dgp# pylint setup.py
************* Module /home/dgp/.pylintrc
.pylintrc:1: [E0015(unrecognized-option), ] Unrecognized option found: accept-no-param-doc, accept-no-return-doc, accept-no-yields-doc
```

After this change, the above example runs without errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/109)
<!-- Reviewable:end -->
