### PR TITLE
fix: virtual environment to be able to run make test

### DIFF
--- a/docs/VIRTUAL_ENV.md
+++ b/docs/VIRTUAL_ENV.md
@@ -16,10 +16,10 @@ While active, running python will run the virtual environment's python, and inst
 
 ```sh
 dgp$ pip install --upgrade pip
-dgp$ pip install cython==0.29.21 numpy==1.19.4 grpcio==1.41.0 grpcio-tools==1.41.0
+dgp$ pip install cython==0.29.21 numpy==1.19.4 grpcio==1.41.0 grpcio-tools==1.41.0 pytest==6.2.5 pytest-timeout==2.0.1
 ```
 
-Finally DGP can be installed. Installing in editable mode means that changes you make to DGP locally will be reflected in the version installed in pip which makes local development very convenient. From DGP repo root:
+Finally DGP can be installed. Installing in editable mode means that changes you make to DGP locally will be reflected in the version installed in pip which makes local development very convenient. From DGP repository root:
 ```sh
 dgp$ pip install --editable .
 ```


### PR DESCRIPTION
The virtual environment expects people can run `make test` without installing pytest.
This PR fixes issue https://github.com/TRI-ML/dgp/issues/104

Before this fix
```
copying dgp/utils/torch_extension/stn.py -> build/lib/dgp/utils/torch_extension
running egg_info
creating dgp.egg-info
writing dgp.egg-info/PKG-INFO
writing dependency_links to dgp.egg-info/dependency_links.txt
writing entry points to dgp.egg-info/entry_points.txt
writing requirements to dgp.egg-info/requires.txt
writing top-level names to dgp.egg-info/top_level.txt
writing manifest file 'dgp.egg-info/SOURCES.txt'
reading manifest file 'dgp.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no previously-included files matching '*.proto' found under directory '*'
writing manifest file 'dgp.egg-info/SOURCES.txt'
PYTHONPATH=/home/nehal/dgp: \
pytest -v /home/nehal/dgp/tests/
/bin/sh: 1: pytest: not found
make: *** [Makefile:72: test] Error 127
```

After this fix

```
================================================= 56 passed, 3 skipped, 4 warnings in 13.57s ==================================================
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/110)
<!-- Reviewable:end -->
