### PR TITLE
fix: fix documentation build and docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,16 @@
-# doc generation directory #
+# Documentation
 
-This directory contains data related to sphinx doc generation
-To generate basic docs, run:
-`make html`
-`sphinx-build -b rinoh source _build/rinoh`
+This directory contains data related to Sphinx doc generation. To generate basic
+docs, run:
 
-**Do not** commit generated html files to version control.
+<!-- `none` is not a language but is required to satisfy SuperLinter in CI -->
+```none
+pip install -r requirements-doc.txt
+make html
+sphinx-build -b rinoh source _build/rinoh
+```
 
-See [the docs](https://www.sphinx-doc.org/en/master/tutorial/index.html) for more information.
+**Do not** commit generated HTML files to version control.
+
+See [the Sphinx docs](https://www.sphinx-doc.org/en/master/tutorial/index.html)
+for more information.

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -1,5 +1,7 @@
+# TODO(tk-woven) Bump mistune version when Sphinx API issue is fixed.
+# https://github.com/sphinx-contrib/openapi/issues/121
 mistune==0.8.4
-m2r2==0.3.1
-rinohtype==0.5.3
+m2r2==0.3.2
+rinohtype==0.5.4
 solar-theme==1.3.3
 Sphinx==4.2.0


### PR DESCRIPTION
# Description

In an attempt to address a CVE (CVE-2022-34749) for one of our docs dependencies, `mistune`, I found multiple issues. The first is that we cannot address the CVE until some Sphinx API issues are solved in upstream Sphinx. The second issue is that our docs building is broken, presumably by the update to Python 3.7 as some regexs from `rinohtype` were failing to compile. This work fixes the docs build and also updates the documentation for completeness.

`m2r2`, which requires `mistune`, was having us install the _newer_ version of `mistune` that breaks against the Sphinx API, so we have to update `m2r2` to use a version that pins against the older `mistune`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/113)
<!-- Reviewable:end -->
