### PR TITLE
feat: move more linters from SuperLinter to pre-commit

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -43,13 +43,16 @@ jobs:
           FILTER_REGEX_EXCLUDE: .*pb2*py
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .
-          PYTHON_PYLINT_CONFIG_FILE: .pylintrc
           VALIDATE_ALL_CODEBASE: false # Only new or edited files will be parsed for validation.
           VALIDATE_DOCKERFILE_HADOLINT: false
+          VALIDATE_GITLEAKS: false # Handled by pre-commit.
+          VALIDATE_HTML: false # Handled by pre-commit.
           VALIDATE_JSCPD: false
+          VALIDATE_JSON: false # Handled by pre-commit.
           VALIDATE_PROTOBUF: false
           VALIDATE_PYTHON_BLACK: false
           VALIDATE_PYTHON_FLAKE8: false # Formatted by YAPF.
           VALIDATE_PYTHON_ISORT: false # Formatted by YAPF.
           VALIDATE_PYTHON_MYPY: false
           VALIDATE_PYTHON_PYLINT: false # Handled by pre-commit.
+          VALIDATE_SHELL_SHFMT: false # Handled by pre-commit.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,18 @@ repos:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-json
+  - repo: https://github.com/zricethezav/gitleaks
+    rev: v8.10.3
+    hooks:
+      - id: gitleaks-docker
+  - repo: https://github.com/Lucas-C/pre-commit-hooks-nodejs
+    rev: v1.1.2
+    hooks:
+      - id: htmlhint
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:
@@ -26,6 +38,11 @@ repos:
     hooks:
       - id: pylint
         args: [--rcfile=.pylintrc]
+  - repo: https://github.com/syntaqx/git-hooks
+    rev: v0.0.17
+    hooks:
+      - id: shellcheck
+      - id: shfmt
   - repo: https://github.com/pre-commit/mirrors-yapf
     rev: v0.32.0
     hooks:


### PR DESCRIPTION
# Description

This is toward #114 . This moves more linting from SuperLinter to pre-commit. In particular, it moves

- check-json
- gitleaks
- htmlhint
- shellcheck
- shfmt

For `gitleaks`, we have to use a Docker-wrapped hook ID to avoid having our end-users manually install the `gitleaks` tool themselves. Also, SuperLinter suggests that it runs `shfmt` but is not entirely clear about it (since its configuration is for `shellcheck`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/122)
<!-- Reviewable:end -->
