### PR TITLE
feat: replace markdownlint with `prettier` Markdown auto-formatting

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -49,6 +49,8 @@ jobs:
           VALIDATE_HTML: false # Handled by pre-commit.
           VALIDATE_JSCPD: false
           VALIDATE_JSON: false # Handled by pre-commit.
+          VALIDATE_MARKDOWN: false # Handled by pre-commit.
+          VALIDATE_NATURAL_LANGUAGE: false # No corresponding pre-commit hook but not critical.
           VALIDATE_PROTOBUF: false
           VALIDATE_PYTHON_BLACK: false
           VALIDATE_PYTHON_FLAKE8: false # Formatted by YAPF.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,12 @@ repos:
     hooks:
       - id: isort
         exclude: _pb2\.py$
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
+    hooks:
+      - id: prettier
+        types: [markdown]
+        args: [--embedded-language-formatting=off, --prose-wrap=always]
   - repo: https://github.com/PyCQA/pylint
     rev: v2.14.5
     hooks:

--- a/README.md
+++ b/README.md
@@ -1,38 +1,43 @@
 <!-- markdownlint-disable-next-line -->
+
 [<img src="docs/tri-logo.png" width="40%">](https://www.tri.global/)
 
-
 # Dataset Governance Policy (DGP)
+
 [![build-docker](https://github.com/TRI-ML/dgp/actions/workflows/build-docker.yml/badge.svg)](https://github.com/TRI-ML/dgp/actions/workflows/build-docker.yml)
 [![license](https://img.shields.io/github/license/TRI-ML/dgp.svg)](https://github.com/TRI-ML/dgp/blob/master/LICENSE)
 [![open-issues](https://img.shields.io/github/issues/TRI-ML/dgp.svg)](https://github.com/TRI-ML/dgp/issues)
 ![coverage badge](./docs/coverage.svg)
 [![docs](https://img.shields.io/badge/documentation-beta-red)](https://tri-ml.github.io/dgp/)
 
-To ensure the traceability, reproducibility and standardization for
-all ML datasets and models generated and consumed within Toyota Research Institute (TRI), we developed the
-Dataset-Governance-Policy (DGP) that codifies the schema and
-maintenance of all TRI's Autonomous Vehicle (AV) datasets.
+To ensure the traceability, reproducibility and standardization for all ML
+datasets and models generated and consumed within Toyota Research Institute
+(TRI), we developed the Dataset-Governance-Policy (DGP) that codifies the schema
+and maintenance of all TRI's Autonomous Vehicle (AV) datasets.
 
 <p align="center">
   <img src="docs/3d-viz-proj.gif" alt="3d-viz-proj"/>
 </p>
 
 ## Components
-- [Schema](dgp/proto/README.md): [Protobuf](https://developers.google.com/protocol-buffers)-based schemas for raw data, annotations
-  and dataset management.
-- [DataLoaders](dgp/datasets): Universal PyTorch DatasetClass to load all DGP-compliant datasets.
-- [CLI](dgp/README.md): Main CLI for handling DGP datasets and the entrypoint of visulization tools.
 
+- [Schema](dgp/proto/README.md):
+  [Protobuf](https://developers.google.com/protocol-buffers)-based schemas for
+  raw data, annotations and dataset management.
+- [DataLoaders](dgp/datasets): Universal PyTorch DatasetClass to load all
+  DGP-compliant datasets.
+- [CLI](dgp/README.md): Main CLI for handling DGP datasets and the entrypoint of
+  visulization tools.
 
 ## Getting Started
+
 Please see [Getting Started](docs/GETTING_STARTED.md) for environment setup.
 
-Getting started is as simple as initializing a dataset-class with the
-relevant dataset JSON, raw data sensor names, annotation types, and
-split information. Below, we show a few examples of initializing a
-Pytorch dataset for multi-modal learning from 2D bounding boxes, and
-3D bounding boxes.
+Getting started is as simple as initializing a dataset-class with the relevant
+dataset JSON, raw data sensor names, annotation types, and split information.
+Below, we show a few examples of initializing a Pytorch dataset for multi-modal
+learning from 2D bounding boxes, and 3D bounding boxes.
+
 ```python
 from dgp.datasets import SynchronizedSceneDataset
 
@@ -45,38 +50,49 @@ dataset = SynchronizedSceneDataset('<dataset_name>_v0.0.json',
 ```
 
 ## Examples
-A list of starter scripts are provided in the [examples](examples/)
-directory.
-- [examples/load_dataset.py](examples/load_dataset.py): Simple example
-  script to load a multi-modal dataset based on the **Getting
-  Started** section above.
+
+A list of starter scripts are provided in the [examples](examples/) directory.
+
+- [examples/load_dataset.py](examples/load_dataset.py): Simple example script to
+  load a multi-modal dataset based on the **Getting Started** section above.
 
 ## Build and run tests
-You can build the base docker image and run the tests within [docker container](docs/GETTING_STARTED.md#markdown-header-develop-within-docker)
+
+You can build the base docker image and run the tests within
+[docker container](docs/GETTING_STARTED.md#markdown-header-develop-within-docker)
 via:
+
 ```sh
 make docker-build
 make docker-run-tests
 ```
 
 ## Contributing
-We appreciate all contributions to DGP! To learn more about making a contribution to DGP, please see [Contribution Guidelines](docs/CONTRIBUTING.md).
+
+We appreciate all contributions to DGP! To learn more about making a
+contribution to DGP, please see [Contribution Guidelines](docs/CONTRIBUTING.md).
 
 ## CI Ecosystem
-| Job | CI | Notes |
-| --- | --- | --- |
-| docker-build | [![Build Status](https://github.com/TRI-ML/dgp/actions/workflows/build-docker.yml/badge.svg)](https://github.com/TRI-ML/dgp/actions/workflows/build-docker.yml) | Docker build and push to [container registry](https://github.com/TRI-ML/dgp/pkgs/container/dgp)|
-| pre-merge    | [![Build Status](https://github.com/TRI-ML/dgp/actions/workflows/pre-merge.yml/badge.svg)](https://github.com/TRI-ML/dgp/actions/workflows/pre-merge.yml) | Pre-merge testing|
-| doc-gen    | [![Build Status](https://github.com/TRI-ML/dgp/actions/workflows/doc-gen.yml/badge.svg)](https://github.com/TRI-ML/dgp/actions/workflows/doc-gen.yml) | [GitHub Pages](https://tri-ml.github.io/dgp/) doc generation|
-| coverage    | [![Build Status](https://github.com/TRI-ML/dgp/actions/workflows/coverage.yml/badge.svg)](https://github.com/TRI-ML/dgp/actions/workflows/coverage.yml) | Code coverage metrics and badge generation |
+
+| Job          | CI                                                                                                                                                              | Notes                                                                                           |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| docker-build | [![Build Status](https://github.com/TRI-ML/dgp/actions/workflows/build-docker.yml/badge.svg)](https://github.com/TRI-ML/dgp/actions/workflows/build-docker.yml) | Docker build and push to [container registry](https://github.com/TRI-ML/dgp/pkgs/container/dgp) |
+| pre-merge    | [![Build Status](https://github.com/TRI-ML/dgp/actions/workflows/pre-merge.yml/badge.svg)](https://github.com/TRI-ML/dgp/actions/workflows/pre-merge.yml)       | Pre-merge testing                                                                               |
+| doc-gen      | [![Build Status](https://github.com/TRI-ML/dgp/actions/workflows/doc-gen.yml/badge.svg)](https://github.com/TRI-ML/dgp/actions/workflows/doc-gen.yml)           | [GitHub Pages](https://tri-ml.github.io/dgp/) doc generation                                    |
+| coverage     | [![Build Status](https://github.com/TRI-ML/dgp/actions/workflows/coverage.yml/badge.svg)](https://github.com/TRI-ML/dgp/actions/workflows/coverage.yml)         | Code coverage metrics and badge generation                                                      |
 
 ## 💬 Where to file bug reports
 
-| Type                     | Platforms                                              |
-| - | - |
-| 🚨 **Bug Reports**       | [GitHub Issue Tracker](https://github.com/TRI-ML/dgp/issues) |
-| 🎁 **Feature Requests**  | [GitHub Issue Tracker](https://github.com/TRI-ML/dgp/issues) |
+| Type                    | Platforms                                                    |
+| ----------------------- | ------------------------------------------------------------ |
+| 🚨 **Bug Reports**      | [GitHub Issue Tracker](https://github.com/TRI-ML/dgp/issues) |
+| 🎁 **Feature Requests** | [GitHub Issue Tracker](https://github.com/TRI-ML/dgp/issues) |
 
-## 👩‍💻  The Team 👨‍💻
+## 👩‍💻 The Team 👨‍💻
 
-DGP is developed and currently maintained by *Quincy Chen, Arjun Bhargava, Chao Fang, Chris Ochoa and Kuan-Hui Lee* from ML-Engineering team at [Toyota Research Institute (TRI)](https://www.tri.global/), with contributions coming from ML-Research team at TRI, [Woven Planet](https://www.woven-planet.global/en) and [Parallel Domain](https://paralleldomain.com/).
+DGP is developed and currently maintained by _Quincy Chen, Arjun Bhargava, Chao
+Fang, Chris Ochoa and Kuan-Hui Lee_ from ML-Engineering team at
+[Toyota Research Institute (TRI)](https://www.tri.global/), with contributions
+coming from ML-Research team at TRI,
+[Woven Planet](https://www.woven-planet.global/en) and
+[Parallel Domain](https://paralleldomain.com/).

--- a/dgp/README.md
+++ b/dgp/README.md
@@ -2,13 +2,13 @@
 
 [dgp/cli.py](cli.py) is the main CLI entrypoint for handling DGP datasets.
 
-
 ## Visualize DGP-compliant Scene and SceneDataset
 
-DGP CLI subcommands `visualize-scenes` and `visualize-scene` can be used to visualize DGP-compliant data.
+DGP CLI subcommands `visualize-scenes` and `visualize-scene` can be used to
+visualize DGP-compliant data.
 
-
-* To visualize a split of a **[DGP SceneDataset](proto/dataset.proto#L127)**, run `python dgp/cli.py visualize-scenes`:
+- To visualize a split of a **[DGP SceneDataset](proto/dataset.proto#L127)**,
+  run `python dgp/cli.py visualize-scenes`:
 
   Show the help message via:
 
@@ -16,26 +16,33 @@ DGP CLI subcommands `visualize-scenes` and `visualize-scene` can be used to visu
   dgp$ python dgp/cli.py visualize-scenes --help
   ```
 
-  Example command to visualize the images from `CAMERA_01, CAMERA_05, CAMERA_06` and point cloud from `LIDAR` along with ground_truth annotations `bounding_box_2d, bounding_box_3d` from `train` split of the toy dataset `tests/data/dgp/test_scene/scene_dataset_v1.0.json`, and store the resulting videos in `--dst-dir vis`.
-One can find the resulting 3D visualization videos in `vis/3d` and 2D visualization videos in `vis/2d`.
+  Example command to visualize the images from `CAMERA_01, CAMERA_05, CAMERA_06`
+  and point cloud from `LIDAR` along with ground_truth annotations
+  `bounding_box_2d, bounding_box_3d` from `train` split of the toy dataset
+  `tests/data/dgp/test_scene/scene_dataset_v1.0.json`, and store the resulting
+  videos in `--dst-dir vis`. One can find the resulting 3D visualization videos
+  in `vis/3d` and 2D visualization videos in `vis/2d`.
 
   ```sh
   dgp$ python dgp/cli.py visualize-scenes --scene-dataset-json tests/data/dgp/test_scene/scene_dataset_v1.0.json --split train --dst-dir vis -l LIDAR -c CAMERA_01 -c CAMERA_05 -c CAMERA_06 -a bounding_box_2d -a bounding_box_3d
   ```
-<p align="center">
-  <img src="https://raw.githubusercontent.com/TRI-ML/dgp/master/docs/3d-viz.gif" alt="3d-viz"/>
-</p>
+
+  <p align="center">
+    <img src="https://raw.githubusercontent.com/TRI-ML/dgp/master/docs/3d-viz.gif" alt="3d-viz"/>
+  </p>
 
 Add flag `render-pointcloud` to render projected pointcloud onto images:
-  ```sh
-  dgp$ python dgp/cli.py visualize-scenes --scene-dataset-json tests/data/dgp/test_scene/scene_dataset_v1.0.json --split train --dst-dir vis -l LIDAR -c CAMERA_01 -c CAMERA_05 -c CAMERA_06 -a bounding_box_2d -a bounding_box_3d --render-pointcloud
-  ```
+
+```sh
+dgp$ python dgp/cli.py visualize-scenes --scene-dataset-json tests/data/dgp/test_scene/scene_dataset_v1.0.json --split train --dst-dir vis -l LIDAR -c CAMERA_01 -c CAMERA_05 -c CAMERA_06 -a bounding_box_2d -a bounding_box_3d --render-pointcloud
+```
+
 <p align="center">
   <img src="https://raw.githubusercontent.com/TRI-ML/dgp/master/docs/3d-viz-proj.gif" alt="3d-viz-proj"/>
 </p>
 
-
-* To visualize a single **[DGP Scene](proto/scene.proto#L14)**, run `python dgp/cli.py visualize-scene`:
+- To visualize a single **[DGP Scene](proto/scene.proto#L14)**, run
+  `python dgp/cli.py visualize-scene`:
 
   Show the help message via:
 
@@ -43,8 +50,12 @@ Add flag `render-pointcloud` to render projected pointcloud onto images:
   dgp$ python dgp/cli.py visualize-scene --help
   ```
 
-  Example command to visualize the images from `CAMERA_01, CAMERA_05, CAMERA_06` and point cloud from `LIDAR` along with ground_truth annotations `bounding_box_2d, bounding_box_3d` from the toy Scene `tests/data/dgp/test_scene/scene_01/scene_a8dc5ed1da0923563f85ea129f0e0a83e7fe1867.json`, and store the resulting videos in `--dst-dir vis`.
-One can find the resulting 3D visualization video in `vis/3d` and 2D visualization video in `vis/2d`.
+  Example command to visualize the images from `CAMERA_01, CAMERA_05, CAMERA_06`
+  and point cloud from `LIDAR` along with ground_truth annotations
+  `bounding_box_2d, bounding_box_3d` from the toy Scene
+  `tests/data/dgp/test_scene/scene_01/scene_a8dc5ed1da0923563f85ea129f0e0a83e7fe1867.json`,
+  and store the resulting videos in `--dst-dir vis`. One can find the resulting
+  3D visualization video in `vis/3d` and 2D visualization video in `vis/2d`.
 
   ```sh
   dgp$ python dgp/cli.py visualize-scene --scene-json tests/data/dgp/test_scene/scene_01/scene_a8dc5ed1da0923563f85ea129f0e0a83e7fe1867.json --dst-dir vis -l LIDAR -c CAMERA_01 -c CAMERA_05 -c CAMERA_06 -a bounding_box_2d -a bounding_box_3d
@@ -52,20 +63,21 @@ One can find the resulting 3D visualization video in `vis/3d` and 2D visualizati
 
 ## Coming soon: Retrieve information about an ML dataset in the DGP
 
-DGP CLI provides information about a dataset, including
-the remote location (S3 url) of the dataset, its raw dataset url, the
-set of available annotation types contained in the dataset, etc. For
-more information, see relevant metadata stored with a dataset artifact
-in [DatasetMetadata](proto/dataset.proto) and [DatasetArtifacts](proto/artifacts.proto).
+DGP CLI provides information about a dataset, including the remote location (S3
+url) of the dataset, its raw dataset url, the set of available annotation types
+contained in the dataset, etc. For more information, see relevant metadata
+stored with a dataset artifact in [DatasetMetadata](proto/dataset.proto) and
+[DatasetArtifacts](proto/artifacts.proto).
+
 ```sh
 dgp$ python dgp/cli.py info --scene-dataset-json <scene-dataset-json>
 ```
 
 ## Coming soon: Validate a dataset
 
-DGP CLI provides a simplified mechanism for validating newly
-created datasets, ensuring that the dataset schema is maintained and
-valid. This is done via:
+DGP CLI provides a simplified mechanism for validating newly created datasets,
+ensuring that the dataset schema is maintained and valid. This is done via:
+
 ```sh
 dgp$ python dgp/cli.py validate --scene-dataset-json <scene-dataset-json>
 ```

--- a/dgp/proto/README.md
+++ b/dgp/proto/README.md
@@ -1,48 +1,56 @@
 # TRI Dataset Governance Policy (DGP) Schema
 
-DGP-compliant datasets follow the structure and schema defined in this directory. Top-level
-data containers are listed below:
+DGP-compliant datasets follow the structure and schema defined in this
+directory. Top-level data containers are listed below:
 
 ## SceneDataset data structure description
 
-* SceneDataset: A SceneDataset contains `DatasetMetadata` and a collection of `Scene`
-assigned to different `split` for training, evaluation and inference.
-* Scene: A Scene consists of consecutive `Sample` extracted at a fixed frequency in
-a robot session. Normally we extract 10~20 seconds Scenes at 10Hz from raw driving logs.
-* Sample: A sample is a container that encapsulates time-synchronized sensory `Datum`
-(images, point clouds, radar point clouds, etc) and calibrations.
-* Datum: A Datum encapsulates sensory data (image, point cloud, radar point cloud, etc),
-along with their associated annotations.
-
+- SceneDataset: A SceneDataset contains `DatasetMetadata` and a collection of
+  `Scene` assigned to different `split` for training, evaluation and inference.
+- Scene: A Scene consists of consecutive `Sample` extracted at a fixed frequency
+  in a robot session. Normally we extract 10~20 seconds Scenes at 10Hz from raw
+  driving logs.
+- Sample: A sample is a container that encapsulates time-synchronized sensory
+  `Datum` (images, point clouds, radar point clouds, etc) and calibrations.
+- Datum: A Datum encapsulates sensory data (image, point cloud, radar point
+  cloud, etc), along with their associated annotations.
 
 ## AgentDataset data structure description
 
-* AgentDataset: Dataset for agent-centric prediction or planning use cases,but guaranteeing trajectory of main agent is present in any fetched sample.
-* AgentSnapshot: An Agent in a Scene can be represented by either an AgentSnapshot2D or AgentSnapshot3D. If it is AgentSnaphot3D, then the agent is represented as a BoundingBox3D along with other fields such as features, instance id's, etc. In case it is represented as AgentSnapshot2D, then a BoundingBox2D is used.
-* AgentSlice: Encapsulates all Agents in a Sample.
-* AgentTrack: The track of a single Agent in the Scene.
-* AgentGroup: Encapsulates all Agents in a Scene.
-* Feature: Agent's requested feature type can include agent_2d, agent_3d, ego_intention, corridor, intersection or parked car.
-* Ontology: An Ontology represents a set of unique objects such as Vehicle, Truck, Pedestrian, etc.
-* Feature Ontology: A Feature Ontology represents a set of unique feature fields such as Speed, Parking attribute, etc.
+- AgentDataset: Dataset for agent-centric prediction or planning use cases,but
+  guaranteeing trajectory of main agent is present in any fetched sample.
+- AgentSnapshot: An Agent in a Scene can be represented by either an
+  AgentSnapshot2D or AgentSnapshot3D. If it is AgentSnaphot3D, then the agent is
+  represented as a BoundingBox3D along with other fields such as features,
+  instance id's, etc. In case it is represented as AgentSnapshot2D, then a
+  BoundingBox2D is used.
+- AgentSlice: Encapsulates all Agents in a Sample.
+- AgentTrack: The track of a single Agent in the Scene.
+- AgentGroup: Encapsulates all Agents in a Scene.
+- Feature: Agent's requested feature type can include agent_2d, agent_3d,
+  ego_intention, corridor, intersection or parked car.
+- Ontology: An Ontology represents a set of unique objects such as Vehicle,
+  Truck, Pedestrian, etc.
+- Feature Ontology: A Feature Ontology represents a set of unique feature fields
+  such as Speed, Parking attribute, etc.
 
 ## Protobuf Directory Structure
 
-All the protobuf schemas are defined under this [proto/](./)
-directory. Schema for the following types are specified their
-corresponding `proto` files.
-* Agent: [`agent.proto`](./agent.proto)
-* Annotations and Annotation Types: [`annotations.proto`](./annotations.proto)
-* Dataset Artifacts: [`artifacts.proto`](./artifacts.proto)
-* Dataset Provenance / Tracking: [`identifiers.proto`](./identifiers.proto)
-* Dataset: [`dataset.proto`](./dataset.proto)
-* Features: [`features.proto`](./features.proto)
-* Image container: [`image.proto`](./image.proto)
-* Ontology: [`ontology.proto`](./ontology.proto)
-* PointCloud container: [`point_cloud.proto`](./point_cloud.proto)
-* Radar PointCloud container: [`radar_point_cloud.proto`](./radar_point_cloud.proto)
-* Remote Storage: [`remote.proto`](./remote.proto)
+All the protobuf schemas are defined under this [proto/](./) directory. Schema
+for the following types are specified their corresponding `proto` files.
 
+- Agent: [`agent.proto`](./agent.proto)
+- Annotations and Annotation Types: [`annotations.proto`](./annotations.proto)
+- Dataset Artifacts: [`artifacts.proto`](./artifacts.proto)
+- Dataset Provenance / Tracking: [`identifiers.proto`](./identifiers.proto)
+- Dataset: [`dataset.proto`](./dataset.proto)
+- Features: [`features.proto`](./features.proto)
+- Image container: [`image.proto`](./image.proto)
+- Ontology: [`ontology.proto`](./ontology.proto)
+- PointCloud container: [`point_cloud.proto`](./point_cloud.proto)
+- Radar PointCloud container:
+  [`radar_point_cloud.proto`](./radar_point_cloud.proto)
+- Remote Storage: [`remote.proto`](./remote.proto)
 
 ### SceneDataset schema graph
 
@@ -51,6 +59,7 @@ corresponding `proto` files.
 ### DGP SceneDataset Structure
 
 Scenes are stored in the DGP under the following structure:
+
 ```filelist
 <dataset_root_dir>
 ├── <scene_name>
@@ -89,7 +98,8 @@ Scenes are stored in the DGP under the following structure:
 ### DGP AgentDataset Structure
 
 Agents are stored in the DGP under the following structure:
-``` text
+
+```text
 📦<dataset_root_dir>
  ┣ 📂<scene_name>
  ┃ ┣ 📂agent
@@ -99,7 +109,7 @@ Agents are stored in the DGP under the following structure:
  ┃ ┃ ┣ 📂<camera_name>
  ┃ ┃ ┃ ┣ 📜<annotation_hash>.json
  ┃ ┃ ┃ ┗ ..
- ┃ ┃ ┗ .. 
+ ┃ ┃ ┗ ..
  ┃ ┣ 📂bounding_box_3d
  ┃ ┃ ┣ 📂<camera_name>
  ┃ ┃ ┃ ┗ 📜<annotation_hash>.json
@@ -131,6 +141,11 @@ Agents are stored in the DGP under the following structure:
 
 ### Autolabel Structure
 
-Autolabes should be stored within their parent scene directory under ```<parent scene dir>/autolabels/<autolabel model>``` folder. Autolabels may also be stored outside of the parent scene folder, in this case they must be stored with the following directory structure: ```<autolabel root>/<parent scene dir basename>/autolabels/<autolabel model>```.
+Autolabes should be stored within their parent scene directory under
+`<parent scene dir>/autolabels/<autolabel model>` folder. Autolabels may also be
+stored outside of the parent scene folder, in this case they must be stored with
+the following directory structure:
+`<autolabel root>/<parent scene dir basename>/autolabels/<autolabel model>`.
 
-In both cases ```<autolabel model>``` should be unique a string denoting which model or process generated the autolabels.
+In both cases `<autolabel model>` should be unique a string denoting which model
+or process generated the autolabels.

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -1,9 +1,10 @@
 # (Optional) Setup AWS for DGP
 
-
 ## Prerequisites
 
-DGP provides utilities functions to download/upload data to [AWS S3](https://aws.amazon.com/pm/serv-s3/). You need an AWS account created to use DGP AWS dependent functions.
+DGP provides utilities functions to download/upload data to
+[AWS S3](https://aws.amazon.com/pm/serv-s3/). You need an AWS account created to
+use DGP AWS dependent functions.
 
 ## Install AWS CLI
 
@@ -12,7 +13,9 @@ From the terminal, run:
 ```sh
 aws --version
 ```
-If you get a response, then you already have AWS CLI installed and can move on to the AWS CLI Configuration section.
+
+If you get a response, then you already have AWS CLI installed and can move on
+to the AWS CLI Configuration section.
 
 Otherwise, you need to install the AWS CLI.
 
@@ -22,7 +25,10 @@ aws --version
 ```
 
 ## AWS CLI Configuration
-Once the AWS CLI is installed, configure the AWS credentials using your AWS Access Key ID and AWS Secret Access Key, you can leave the default format to None:
+
+Once the AWS CLI is installed, configure the AWS credentials using your AWS
+Access Key ID and AWS Secret Access Key, you can leave the default format to
+None:
 
 ```sh
 aws configure

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contribution Guidelines
 
-Welcome to `TRI-ML/dgp`! This page details contribution guidelines and GitWorkflow.
+Welcome to `TRI-ML/dgp`! This page details contribution guidelines and
+GitWorkflow.
 
 ## Clone the repository
 
@@ -18,11 +19,13 @@ dgp$ make link-githooks
 
 ## Getting started
 
-Please follow [Getting Started](GETTING_STARTED.md) to setup dockerized development workflow.
+Please follow [Getting Started](GETTING_STARTED.md) to setup dockerized
+development workflow.
 
 ## GitWorkflow
 
-This section assumes you have followed the initial setup instructions and enable the githooks.
+This section assumes you have followed the initial setup instructions and enable
+the githooks.
 
 ### Starting a new branch
 
@@ -31,8 +34,11 @@ This section assumes you have followed the initial setup instructions and enable
 
 ### Making a commit
 
-There should only be a single commit with all the changes when making a pull request. Please squash the commits before opening a PR.
-This repository follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) for the commit message convention. All commit messages will be verified by [commitlint](https://github.com/conventional-changelog/commitlint).
+There should only be a single commit with all the changes when making a pull
+request. Please squash the commits before opening a PR. This repository follows
+[Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) for
+the commit message convention. All commit messages will be verified by
+[commitlint](https://github.com/conventional-changelog/commitlint).
 
 The commit message should be structured as follows:
 
@@ -44,18 +50,25 @@ The commit message should be structured as follows:
 [optional footer(s)]
 ```
 
-When naming the commit, the first line (commit title) should be a short summary **in ALL lowercase** and starts with a `type`. [Common types](https://github.com/conventional-changelog/commitlint/tree/master/@commitlint/config-conventional#type-enum) can be:
+When naming the commit, the first line (commit title) should be a short summary
+**in ALL lowercase** and starts with a `type`.
+[Common types](https://github.com/conventional-changelog/commitlint/tree/master/@commitlint/config-conventional#type-enum)
+can be:
 
-- `schema`: changes to dgp [protobuf schema](https://github.com/TRI-ML/dgp/tree/master/dgp/proto)
+- `schema`: changes to dgp
+  [protobuf schema](https://github.com/TRI-ML/dgp/tree/master/dgp/proto)
 - `feat`: introduce new features
 - `fix`: bugfix
 - `test`: changes to unit tests
-- `build`: changes that affect the package build or external dependencies (example: requirement.txt and Dockerfile updates)
+- `build`: changes that affect the package build or external dependencies
+  (example: requirement.txt and Dockerfile updates)
 - `docs`: documentation only changes
 - `ci`: changes to CI/CD configuration files and settings
-- `style`: changes that do not affect the meaning of the code (formatting, linting, etc)
+- `style`: changes that do not affect the meaning of the code (formatting,
+  linting, etc)
 - `refactor`: a code change that neither fixes a bug nor adds a feature
-- `perf`: changes that improve performance (example: speed up dataset index building)
+- `perf`: changes that improve performance (example: speed up dataset index
+  building)
 - `revert`: revert a commit
 
 For example, adding a new PyTorch DatasetClass:
@@ -76,12 +89,15 @@ schema: add map schema
 - modify dgp.proto.dataset to hold map message
 ```
 
-**NOTE:** For adding any new [proto schema](../dgp/proto), please run `make build-proto` and also commit the compiled protos. Further, these [proto schema](../dgp/proto) and their compiled protos must be separated from code changes into one independent commit and PR.
-
+**NOTE:** For adding any new [proto schema](../dgp/proto), please run
+`make build-proto` and also commit the compiled protos. Further, these
+[proto schema](../dgp/proto) and their compiled protos must be separated from
+code changes into one independent commit and PR.
 
 ### Pre-commit / Pre-push
 
-DGP runs `isort` and `yapf` to autoformat the files in pre-commit, and perform additional linting using `pylint` in pre-push. One can enable githooks via:
+DGP runs `isort` and `yapf` to autoformat the files in pre-commit, and perform
+additional linting using `pylint` in pre-push. One can enable githooks via:
 
 ```sh
 dgp$ make link-githooks
@@ -89,9 +105,17 @@ dgp$ make link-githooks
 
 ### Making a pull request
 
-Please follow this procedure to open a pull request. Also note, the git hooks require that tools such as isort and yapf are installed on the machine doing the git push. If these are not available on your system, you will first need to install them, ideally in the [docker container](GETTING_STARTED.md#markdown-develop-within-docker) or in a [virtual environment](VIRTUAL_ENV.md).
+Please follow this procedure to open a pull request. Also note, the git hooks
+require that tools such as isort and yapf are installed on the machine doing the
+git push. If these are not available on your system, you will first need to
+install them, ideally in the
+[docker container](GETTING_STARTED.md#markdown-develop-within-docker) or in a
+[virtual environment](VIRTUAL_ENV.md).
 
-All changes require unit tests. PRs can only be merged if the code coverage score is greater than the minimum acceptable code coverage. The minimum acceptable code coverage score is set [here](https://github.com/TRI-ML/dgp/blob/master/.github/workflows/coverage.yml#L15).
+All changes require unit tests. PRs can only be merged if the code coverage
+score is greater than the minimum acceptable code coverage. The minimum
+acceptable code coverage score is set
+[here](https://github.com/TRI-ML/dgp/blob/master/.github/workflows/coverage.yml#L15).
 
 1. Rebase to master
    - `git fetch upstream`
@@ -99,28 +123,41 @@ All changes require unit tests. PRs can only be merged if the code coverage scor
 2. Push to your GitHub fork
    - `git push origin`
 3. Create "Pull Request" (PR)
-   - Go to your fork in GitHub and create a pull request per [these instructions](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)
+   - Go to your fork in GitHub and create a pull request per
+     [these instructions](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)
 4. CI coverage
    - You can run unittests via `make docker-run-tests`.
    - You can make PRs with no reviewers to get CI coverage.
    - All pull requests must pass certain stages in order to be merged:
-     - Build & unit tests via [pre-merge](https://github.com/TRI-ML/dgp/actions/workflows/pre-merge.yml) workflow.
-     - Linting/formatting checks via [pre-merge](https://github.com/TRI-ML/dgp/actions/workflows/pre-merge.yml) workflow.
-     - Code coverage metrics verification via [coverage](https://github.com/TRI-ML/dgp/actions/workflows/coverage.yml) workflow.
+     - Build & unit tests via
+       [pre-merge](https://github.com/TRI-ML/dgp/actions/workflows/pre-merge.yml)
+       workflow.
+     - Linting/formatting checks via
+       [pre-merge](https://github.com/TRI-ML/dgp/actions/workflows/pre-merge.yml)
+       workflow.
+     - Code coverage metrics verification via
+       [coverage](https://github.com/TRI-ML/dgp/actions/workflows/coverage.yml)
+       workflow.
 
 ### Review
 
-The pull request has a reviewable.io review associated with it. (You will need to reload the pull request page before the reviewable.io button appears). Please add at least one reviewer to review.
-Note: Any [proto schema](../dgp/proto) changes require _**at least 2 reviewers.**_
+The pull request has a reviewable.io review associated with it. (You will need
+to reload the pull request page before the reviewable.io button appears). Please
+add at least one reviewer to review. Note: Any [proto schema](../dgp/proto)
+changes require _**at least 2 reviewers.**_
 
 ### Merging
 
-Once all reviews are complete, and all checks have completed with passing scores, the author can click the button `Squash & Merge` to merge the PR.
+Once all reviews are complete, and all checks have completed with passing
+scores, the author can click the button `Squash & Merge` to merge the PR.
 
 ### Code Style
 
-Docstrings should follow the [Numpy Docstring Standard](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
+Docstrings should follow the
+[Numpy Docstring Standard](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
 
 ### Test Coverage Policy
 
-All commits (except protobuf schema changes) should include test cases. Test cases should be based on pytest. PRs can only be merged if the code coverage score is greater than the minimum acceptable code coverage.
+All commits (except protobuf schema changes) should include test cases. Test
+cases should be based on pytest. PRs can only be merged if the code coverage
+score is greater than the minimum acceptable code coverage.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -10,28 +10,32 @@
 
 ## Installation
 
-Dockerized environment is encouraged for all DGP contributors and users. Alternatively, you can use python virtual environments. Please see [virtual environment setup](VIRTUAL_ENV.md) for instructions.
+Dockerized environment is encouraged for all DGP contributors and users.
+Alternatively, you can use python virtual environments. Please see
+[virtual environment setup](VIRTUAL_ENV.md) for instructions.
 
 To setup DGP docker image:
 
 - You can pull the latest master docker via:
 
-   ```sh
-   dgp$ docker pull ghcr.io/tri-ml/dgp:master && docker image tag ghcr.io/tri-ml/dgp:master dgp:latest
-   ```
-   ---or---
+  ```sh
+  dgp$ docker pull ghcr.io/tri-ml/dgp:master && docker image tag ghcr.io/tri-ml/dgp:master dgp:latest
+  ```
+
+  ---or---
 
 - Build the docker from scratch via:
 
-    ```sh
-    dgp$ make docker-build
-    ```
+  ```sh
+  dgp$ make docker-build
+  ```
 
 Inspect if docker image `dgp:latest` has been pulled or built successfully:
 
 ```sh
 dgp$ docker inspect --type=image dgp:latest
 ```
+
 If you get a response, then you already have DGP docker image on the machine!
 
 To check if DGP docker image is built successfully, run the unit tests via:
@@ -41,17 +45,22 @@ dgp$ make docker-run-tests
 ```
 
 ## Develop within docker
-In order to start development, the quickest way to get started would
-be use the interactive docker mode via:
+
+In order to start development, the quickest way to get started would be use the
+interactive docker mode via:
+
 ```sh
 dgp$ make docker-start-interactive
 ```
 
-The DGP base directory is mounted within the
-docker container, and gives you a sandbox to develop quickly without
-needing to set up a local virtual environment.
+The DGP base directory is mounted within the docker container, and gives you a
+sandbox to develop quickly without needing to set up a local virtual
+environment.
 
-Within the interactive docker container (after `make docker-start-interactive`), you can now build the proto definitions (`make build-proto`) and run the tests (`make test`) to make sure everything is functioning properly.
+Within the interactive docker container (after `make docker-start-interactive`),
+you can now build the proto definitions (`make build-proto`) and run the tests
+(`make test`) to make sure everything is functioning properly.
+
 ```sh
 dgp$ make build-proto
 dgp$ make test
@@ -60,7 +69,7 @@ dgp$ make test
 To set up linters wherever you plan on using `git` from (either on your host or
 inside the container), run
 
-```none
+```
 # If in Docker, run the following; otherwise skip this block.
 dgp$ apt update
 dgp$ apt install -y git
@@ -70,7 +79,7 @@ dgp$ git config --global --add safe.directory /home/dgp
 dgp$ make setup-linters
 ```
 
-You may need to first `pip install pre-commit` if you use `git` in an environment
-that does not have DGP's `requirements-dev.txt` installed. Note that if you run
-linting outside of Docker, ensure that you use the same Python version DGP's Docker
-environment uses for a consistent linting experience.
+You may need to first `pip install pre-commit` if you use `git` in an
+environment that does not have DGP's `requirements-dev.txt` installed. Note that
+if you run linting outside of Docker, ensure that you use the same Python
+version DGP's Docker environment uses for a consistent linting experience.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,8 +3,7 @@
 This directory contains data related to Sphinx doc generation. To generate basic
 docs, run:
 
-<!-- `none` is not a language but is required to satisfy SuperLinter in CI -->
-```none
+```
 pip install -r requirements-doc.txt
 make html
 sphinx-build -b rinoh source _build/rinoh

--- a/docs/VIRTUAL_ENV.md
+++ b/docs/VIRTUAL_ENV.md
@@ -1,18 +1,24 @@
 # Virtual Environment Installation
 
-DGP can be installed into a virtual environment and is a convenient way of developing locally and testing small changes.
+DGP can be installed into a virtual environment and is a convenient way of
+developing locally and testing small changes.
 
-To make a new virtual environment named ```env```:
+To make a new virtual environment named `env`:
 
 ```sh
 dgp$ python3 -m venv env
 ```
 
 Activate your virtual environment.
+
 ```sh
 dgp$ source env/bin/activate
 ```
-While active, running python will run the virtual environment's python, and installing packages with pip will install them to the virtual environment's site-packages. You will need to install a few dependencies prior to installing DGP.
+
+While active, running python will run the virtual environment's python, and
+installing packages with pip will install them to the virtual environment's
+site-packages. You will need to install a few dependencies prior to installing
+DGP.
 
 ```sh
 dgp$ pip install --upgrade pip
@@ -20,33 +26,39 @@ dgp$ pip install cython==0.29.21 numpy==1.19.4
 dgp$ pip install -r requirements.txt -r requirements-dev.txt
 ```
 
-Finally DGP can be installed. Installing in editable mode means that changes you make to DGP locally will be reflected in the version installed in pip which makes local development very convenient. From DGP repository root:
+Finally DGP can be installed. Installing in editable mode means that changes you
+make to DGP locally will be reflected in the version installed in pip which
+makes local development very convenient. From DGP repository root:
+
 ```sh
 dgp$ pip install --editable .
 ```
 
 To check if DGP is installed correctly, run the unit tests by running:
+
 ```sh
 dgp$ make test
 ```
 
 Run DGP CLI via:
+
 ```sh
 dgp$ dgp_cli --help
 ```
 
-While most changes will be reflected automatically in editable mode, any changes to the protos, which require their own build step, will need to be run manually.
+While most changes will be reflected automatically in editable mode, any changes
+to the protos, which require their own build step, will need to be run manually.
 To update any changes to the protos, please run make develop again.
 
-
 Finally to deactivate the environment
+
 ```sh
 dgp$ deactivate
 ```
 
 To set up linters, run
 
-```none
+```
 dgp$ make setup-linters
 ```
 


### PR DESCRIPTION
# Description

This is toward #114 . SuperLinter uses `markdownlint` for linting Markdown. When running the latest version on DGP, I found many violations. Instead of manually requiring conformance to specific style, I replace `markdownlint` with `prettier` which will auto-format Markdown files for us.

I've also disabled the natural language validator since there is no corresponding pre-commit hook for it. I don't think this validator is critical. What's more important is that we enforce clear meaning in prose in code review.

Lastly, I've built the docs locally and glanced over them (rather quickly). Everything seems to be okay still, including the PDF generated by `rinoh`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/123)
<!-- Reviewable:end -->
