### PR TITLE
feat: add GitHub issue templates with default assignees

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: "Bug Report"
+about: Submit a bug report to help us improve DGP
+assignees: chrisochoatri, kuanleetri, ryo-takahashi-1206, tk-woven, wadimkehl, ykkawana-woven
+
+---
+
+# Bug
+
+<!--
+Here, write a clear and concise description of what the bug is.
+Please also share your operating system, its version, and your Python version.
+If you have error messages, stack traces, etc., please also share them here.
+-->
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+
+1.
+
+<!--
+If possible, please prepare and share a minimum reproducible code example.
+-->
+
+## Expected behavior
+
+<!-- Share a clear, concise description of what you expected to happen. -->
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+# Require issue creators to use our templates.
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: "Feature Request"
+about: Submit a proposal/request for a new feature in DGP
+assignees: chrisochoatri, kuanleetri, ryo-takahashi-1206, tk-woven, wadimkehl, ykkawana-woven
+
+---
+
+# Feature
+
+<!--
+Here, briefly introduce your feature proposal and your motivation for proposing.
+If this is related to another GitHub issue, please link to that issue as well.
+-->
+
+## Proposal
+
+<!--
+Here, write a clear description of what you want implemented. Go into
+technical detail whenever it helps to explain your request or whenever one
+particular implementation should be considered over another.
+-->
+
+## Alternatives
+
+<!--
+Here, write a clear, concise description of any alternative solutions you've
+considered, if any.
+-->
+
+## Additional context
+
+<!-- Add any other context about the feature request here. -->


### PR DESCRIPTION
# Description

This introduces issue templates for GitHub issues. Issue templates present issue creators with options between different pre-populated issue bodies. See FAIR's [Detectron2 New-Issues](https://github.com/facebookresearch/detectron2/issues/new/choose) for an example.

This also adds a number of default assignees. The default assignees are not required to solve the issues themselves, but they are added so that at least someone gets a notification when a new issue is opened. This way we can triage or re-assign as needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/127)
<!-- Reviewable:end -->
