### PR TITLE
docs: remove version-hardcofing from Sphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+from subprocess import run
 
 import solar_theme
 
@@ -26,7 +27,8 @@ copyright = '2021, Toyota Research Institute'
 author = 'Toyota Research Institute'
 
 # The full version, including alpha/beta/rc tags
-release = '1.0'
+cmd = "git describe --tags --match v[0-9]*.[0-9]*"
+release = run(cmd.split(), capture_output=True, check=True).stdout.decode().strip()
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
In order to resolve #116, I propose to use `git describe`.  
In future, I will fold past major release into the single doc as other popular projects do.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/128)
<!-- Reviewable:end -->
