### PR TITLE
fix: do the deep clone in a GH action, "doc-gen"

### DIFF
--- a/.github/workflows/doc-gen.yml
+++ b/.github/workflows/doc-gen.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - 'master'
+  pull_request:
+    branches:
+      - 'master'
+
 jobs:
   run:
     runs-on: ubuntu-20.04
@@ -12,7 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
         with:
-          fetch-depth: "1"
+          # To parse `git tag` in the following `make html`,
+          # intentionally do the deep clone here.
+          fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@master
         with:
@@ -20,13 +26,15 @@ jobs:
       - name: Setup requirements and run sphinx
         run: |
           python -m pip install --upgrade pip
-            pip install cython==0.29.21 numpy==1.23.2
+          pip install cython==0.29.21 numpy==1.23.2
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
           pip install -r docs/requirements-doc.txt
           cd docs
           make html
       - name: Push Sphinx Pages to Webserver
+        # Avoid publishing on pull_request.
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
           branch: gh-pages


### PR DESCRIPTION
# Summary

## 1. Overview

* As shown in [this run](https://github.com/TRI-ML/dgp/actions/runs/3050002270),  "PR #128" causes a build break
* I confirmed `actions/checkout` in "doc-gen" does only a shallow clone, which fetch no `git tag`


## 2. Implementation details

- Change `actions/checkout` to the deep clone in "doc-gen" 
- Not to repeat this stupid mistake, I propose to trigger "doc-gen" also at pre-merge (i.e. `on.pull_request`)
- However, to avoid messy `git push` in GH pages, I introduce a skip condition depending on  `github.ref `

## 3. Future Work

* Fold per-tag Sphinx docs into the single GH pages like other projects

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/129)
<!-- Reviewable:end -->
