### PR TITLE
fix: supported extensions in compute_image_statistics method

### DIFF
--- a/dgp/utils/dataset_conversion.py
+++ b/dgp/utils/dataset_conversion.py
@@ -69,21 +69,24 @@ def compute_image_statistics(image_list, image_open_fn, single_process=False, nu
 
     all_image_sizes: dict
         Dict mapping from filenames to image sizes (C, H, W)
+
+    Raises
+    ------
+    ValueError
+        Raised if all the images are invalid extensions.
     """
 
     valid_extensions = (
         ".jpg",
+        ".jpeg"
         ".png",
         ".bmp",
         ".pgm",
         ".tiff",
-        ".JPG",
-        ".PNG",
-        ".BMP",
-        ".PGM",
-        ".TIFF",
     )
-    image_list = list(filter(lambda x: x.endswith(valid_extensions), image_list))
+    image_list = list(filter(lambda x: x.lower().endswith(valid_extensions), image_list))
+    if not image_list:
+        raise ValueError("There are no valid images for image statistics calculation.")
 
     if single_process:
         image_stats_per_process = []

--- a/dgp/utils/dataset_conversion.py
+++ b/dgp/utils/dataset_conversion.py
@@ -71,7 +71,18 @@ def compute_image_statistics(image_list, image_open_fn, single_process=False, nu
         Dict mapping from filenames to image sizes (C, H, W)
     """
 
-    valid_extensions = (".jpg", ".png", ".bmp", ".pgm", ".tiff")
+    valid_extensions = (
+        ".jpg",
+        ".png",
+        ".bmp",
+        ".pgm",
+        ".tiff",
+        ".JPG",
+        ".PNG",
+        ".BMP",
+        ".PGM",
+        ".TIFF",
+    )
     image_list = list(filter(lambda x: x.endswith(valid_extensions), image_list))
 
     if single_process:


### PR DESCRIPTION
Some ML teams are handling image data with uppercase extensions such as `.JPG`, `.PNG`.
If there are no negative effects, I would like to support such uppercase extensions in `compute_image_statistics` method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/130)
<!-- Reviewable:end -->
