### PR TITLE
fix: fixed depth in dgp2wicker

### DIFF
--- a/dgp/contribs/dgp2wicker/dgp2wicker/dataset.py
+++ b/dgp/contribs/dgp2wicker/dgp2wicker/dataset.py
@@ -82,6 +82,8 @@ def compute_columns(
     if with_ontology_table and requested_annotations is not None:
         for ann in requested_annotations:
             if ann in ANNOTATION_REGISTRY:
+                if ann == 'depth':  # DenseDepth does not require an ontology
+                    continue
                 columns_to_load.append(gen_wicker_key('ontology', ann))
 
     return columns_to_load


### PR DESCRIPTION
Fixes a small error in dgp2wicker base dataset. Depth is the only annotation type that does not have an ontology.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/133)
<!-- Reviewable:end -->
