### PR TITLE
feat: add alternate scene location for dgp2wicker

### DIFF
--- a/dgp/contribs/dgp2wicker/dgp2wicker/cli.py
+++ b/dgp/contribs/dgp2wicker/dgp2wicker/cli.py
@@ -65,6 +65,7 @@ def cli():
 @click.option("--data-uri", required=False, default=None, help="Alternate location for scene data")
 @click.option("--add-lidar-points", is_flag=True, help="Add lidar point count to lidar cuboids")
 @click.option("--half-size-images", is_flag=True, help="Resize image datums to half size")
+@click.option("--alternate-scene-uri", required=False, default=None, help="Alternate scene locaiton to sync")
 def ingest(
     scene_dataset_json,
     wicker_dataset_name,
@@ -82,6 +83,7 @@ def ingest(
     data_uri,
     add_lidar_points,
     half_size_images,
+    alternate_scene_uri,
 ):
     datum_names = [x.strip() for x in datum_names.split(',')]
     requested_annotations = [x.strip() for x in requested_annotations.split(',')] if requested_annotations else None
@@ -112,6 +114,7 @@ def ingest(
         num_repartitions=num_repartitions,
         is_pd=is_pd,
         data_uri=data_uri,
+        alternate_scene_uri=alternate_scene_uri,
     )
 
     print('Finished ingest!')


### PR DESCRIPTION
This adds support for syncing data from two locations when converting to wicker. A common use case is if the scene dataset json references a scene with just annotations or perhaps backfill for a missing datum (ex radar), and we also need to convert the raw data for this scene stored elsewhere.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/141)
<!-- Reviewable:end -->
