### PR TITLE
feat: add key_point_2d/3d and key_line_2d/3d to dgp2wicker

### DIFF
--- a/dgp/annotations/__init__.py
+++ b/dgp/annotations/__init__.py
@@ -21,6 +21,7 @@ from dgp.annotations.semantic_segmentation_2d_annotation import SemanticSegmenta
 from dgp.annotations.key_line_2d_annotation import KeyLine2DAnnotationList  # isort:skip
 from dgp.annotations.key_line_3d_annotation import KeyLine3DAnnotationList  # isort:skip
 from dgp.annotations.key_point_2d_annotation import KeyPoint2DAnnotationList  # isort:skip
+from dgp.annotations.key_point_3d_annotation import KeyPoint3DAnnotationList # isort:skip
 from dgp.annotations.depth_annotation import DenseDepthAnnotation  # isort:skip
 
 # Ontology handlers for each annotation type
@@ -50,6 +51,7 @@ ANNOTATION_REGISTRY = {
     "semantic_segmentation_2d": SemanticSegmentation2DAnnotation,
     "instance_segmentation_2d": PanopticSegmentation2DAnnotation,
     "key_point_2d": KeyPoint2DAnnotationList,
+    "key_point_3d": KeyPoint3DAnnotationList,
     "key_line_2d": KeyLine2DAnnotationList,
     "key_line_3d": KeyLine3DAnnotationList,
     "depth": DenseDepthAnnotation
@@ -69,5 +71,7 @@ ANNOTATION_TYPE_TO_ANNOTATION_GROUP = {
     "motion_vectors_3d": "3d",
     "key_point_2d": "2d",
     "key_line_2d": "2d",
+    "key_point_3d": "3d",
+    "key_line_3d": "3d",
     "depth": "2d"
 }

--- a/dgp/annotations/__init__.py
+++ b/dgp/annotations/__init__.py
@@ -21,7 +21,7 @@ from dgp.annotations.semantic_segmentation_2d_annotation import SemanticSegmenta
 from dgp.annotations.key_line_2d_annotation import KeyLine2DAnnotationList  # isort:skip
 from dgp.annotations.key_line_3d_annotation import KeyLine3DAnnotationList  # isort:skip
 from dgp.annotations.key_point_2d_annotation import KeyPoint2DAnnotationList  # isort:skip
-from dgp.annotations.key_point_3d_annotation import KeyPoint3DAnnotationList # isort:skip
+from dgp.annotations.key_point_3d_annotation import KeyPoint3DAnnotationList  # isort:skip
 from dgp.annotations.depth_annotation import DenseDepthAnnotation  # isort:skip
 
 # Ontology handlers for each annotation type

--- a/dgp/annotations/bounding_box_2d_annotation.py
+++ b/dgp/annotations/bounding_box_2d_annotation.py
@@ -9,7 +9,7 @@ from dgp.proto.annotations_pb2 import (
 )
 from dgp.utils.protobuf import (
     generate_uid_from_pbobject,
-    open_pbobject,
+    parse_pbobject,
     save_pbobject_as_json,
 )
 from dgp.utils.structures.bounding_box_2d import BoundingBox2D
@@ -41,8 +41,8 @@ class BoundingBox2DAnnotationList(Annotation):
 
         Parameters
         ----------
-        annotation_file: str
-            Full path to annotation
+        annotation_file: str or bytes
+            Full path to annotation or bytestring
 
         ontology: BoundingBoxOntology
             Ontology for 2D bounding box tasks.
@@ -52,8 +52,7 @@ class BoundingBox2DAnnotationList(Annotation):
         BoundingBox2DAnnotationList
             Annotation object instantiated from file.
         """
-
-        _annotation_pb2 = open_pbobject(annotation_file, BoundingBox2DAnnotations)
+        _annotation_pb2 = parse_pbobject(annotation_file, BoundingBox2DAnnotations)
         boxlist = [
             BoundingBox2D(
                 box=np.float32([ann.box.x, ann.box.y, ann.box.w, ann.box.h]),

--- a/dgp/annotations/bounding_box_3d_annotation.py
+++ b/dgp/annotations/bounding_box_3d_annotation.py
@@ -11,7 +11,7 @@ from dgp.utils.camera import Camera
 from dgp.utils.pose import Pose
 from dgp.utils.protobuf import (
     generate_uid_from_pbobject,
-    open_pbobject,
+    parse_pbobject,
     save_pbobject_as_json,
 )
 from dgp.utils.structures.bounding_box_3d import BoundingBox3D
@@ -45,8 +45,8 @@ class BoundingBox3DAnnotationList(Annotation):
 
         Parameters
         ----------
-        annotation_file: str
-            Full path to annotation
+        annotation_file: str or bytes
+            Full path to annotation or bytestring
 
         ontology: BoundingBoxOntology
             Ontology for 3D bounding box tasks.
@@ -56,7 +56,7 @@ class BoundingBox3DAnnotationList(Annotation):
         BoundingBox3DAnnotationList
             Annotation object instantiated from file.
         """
-        _annotation_pb2 = open_pbobject(annotation_file, BoundingBox3DAnnotations)
+        _annotation_pb2 = parse_pbobject(annotation_file, BoundingBox3DAnnotations)
         boxlist = [
             BoundingBox3D(
                 pose=Pose.load(ann.box.pose),

--- a/dgp/annotations/camera_transforms.py
+++ b/dgp/annotations/camera_transforms.py
@@ -648,6 +648,7 @@ class AffineCameraTransform(BaseTransform):
             # TODO(chrisochoatri): remove zero w and h boxes
             # TODO(chrisochoatri): clip to image size
             # TODO(chrisochoatri): maybe convert back to int if input is int?
+            # TODO(chrisochoatri): re-estimate 2d boxes after transform from instance masks if available
 
         if 'semantic_segmentation_2d' in new_datum:
             sem_seg = new_datum['semantic_segmentation_2d']
@@ -676,7 +677,7 @@ class AffineCameraTransform(BaseTransform):
 
         if 'key_line_3d' in new_datum:
             raise NotImplementedError('key_line_3d not yet supported')
-        
+
         if 'key_point_3d' in new_datum:
             raise NotImplementedError('key_point_3d not yet supported')
 

--- a/dgp/annotations/camera_transforms.py
+++ b/dgp/annotations/camera_transforms.py
@@ -596,6 +596,11 @@ class AffineCameraTransform(BaseTransform):
         -------
         new_datum: OrderedDict
             Camera datum with transformed image and annotations.
+
+        Raises
+        ------
+        NotImplementedError
+            If any field is not yet supported.
         """
 
         assert cam_datum['datum_type'] == 'image', 'expected an image datum_type'

--- a/dgp/annotations/camera_transforms.py
+++ b/dgp/annotations/camera_transforms.py
@@ -626,7 +626,7 @@ class AffineCameraTransform(BaseTransform):
         new_datum['pose'] = pose
         new_datum['extrinsics'] = ext
 
-        # This is not actually part of DGP, but you define a mask for the image, we can keep track of points
+        # This is not actually part of DGP, but if you define a mask for the image, we can keep track of points
         # that are not part of that mask a result of these operations.
         if 'rgb_mask' in new_datum:
             rgb_mask = new_datum['rgb_mask']
@@ -673,6 +673,12 @@ class AffineCameraTransform(BaseTransform):
             keylines = new_datum['key_line_2d']
             keylines = self.transform_keylines_2d(keylines, )
             new_datum['key_line_2d'] = keylines
+
+        if 'key_line_3d' in new_datum:
+            raise NotImplementedError('key_line_3d not yet supported')
+        
+        if 'key_point_3d' in new_datum:
+            raise NotImplementedError('key_point_3d not yet supported')
 
         # TODO(chrisochoatri): verify behavior when Nonetype is passed for each annotation
         # TODO(chrisochoatri): line 2d/3d annotations

--- a/dgp/annotations/key_line_2d_annotation.py
+++ b/dgp/annotations/key_line_2d_annotation.py
@@ -6,7 +6,7 @@ from dgp.annotations.ontology import KeyLineOntology
 from dgp.proto.annotations_pb2 import KeyLine2DAnnotation, KeyLine2DAnnotations
 from dgp.utils.protobuf import (
     generate_uid_from_pbobject,
-    open_pbobject,
+    parse_pbobject,
     save_pbobject_as_json,
 )
 from dgp.utils.structures.key_line_2d import KeyLine2D
@@ -39,8 +39,8 @@ class KeyLine2DAnnotationList(Annotation):
 
         Parameters
         ----------
-        annotation_file: str
-            Full path to annotation
+        annotation_file: str or bytes
+            Full path to annotation or bytestring
 
         ontology: KeyLineOntology
             Ontology for 2D keyline tasks.
@@ -50,7 +50,7 @@ class KeyLine2DAnnotationList(Annotation):
         KeyLine2DAnnotationList
             Annotation object instantiated from file.
         """
-        _annotation_pb2 = open_pbobject(annotation_file, KeyLine2DAnnotations)
+        _annotation_pb2 = parse_pbobject(annotation_file, KeyLine2DAnnotations)
         linelist = [
             KeyLine2D(
                 line=np.float32([[vertex.x, vertex.y] for vertex in ann.vertices]),

--- a/dgp/annotations/key_line_3d_annotation.py
+++ b/dgp/annotations/key_line_3d_annotation.py
@@ -6,7 +6,7 @@ from dgp.annotations.ontology import KeyLineOntology
 from dgp.proto.annotations_pb2 import KeyLine3DAnnotation, KeyLine3DAnnotations
 from dgp.utils.protobuf import (
     generate_uid_from_pbobject,
-    open_pbobject,
+    parse_pbobject,
     save_pbobject_as_json,
 )
 from dgp.utils.structures.key_line_3d import KeyLine3D
@@ -39,8 +39,8 @@ class KeyLine3DAnnotationList(Annotation):
 
         Parameters
         ----------
-        annotation_file: str
-            Full path to annotation
+        annotation_file: str or bytes
+            Full path to annotation or bytestring
 
         ontology: KeyLineOntology
             Ontology for 3D keyline tasks.
@@ -50,7 +50,7 @@ class KeyLine3DAnnotationList(Annotation):
         KeyLine3DAnnotationList
             Annotation object instantiated from file.
         """
-        _annotation_pb2 = open_pbobject(annotation_file, KeyLine3DAnnotations)
+        _annotation_pb2 = parse_pbobject(annotation_file, KeyLine3DAnnotations)
         linelist = [
             KeyLine3D(
                 line=np.float32([[vertex.x, vertex.y, vertex.z] for vertex in ann.vertices]),

--- a/dgp/annotations/key_point_2d_annotation.py
+++ b/dgp/annotations/key_point_2d_annotation.py
@@ -9,7 +9,7 @@ from dgp.proto.annotations_pb2 import (
 )
 from dgp.utils.protobuf import (
     generate_uid_from_pbobject,
-    open_pbobject,
+    parse_pbobject,
     save_pbobject_as_json,
 )
 from dgp.utils.structures.key_point_2d import KeyPoint2D
@@ -41,8 +41,8 @@ class KeyPoint2DAnnotationList(Annotation):
 
         Parameters
         ----------
-        annotation_file: str
-            Full path to annotation
+        annotation_file: str or bytes
+            Full path to annotation or bytestring
 
         ontology: KeyPointOntology
             Ontology for 2D keypoint tasks.
@@ -52,7 +52,7 @@ class KeyPoint2DAnnotationList(Annotation):
         KeyPoint2DAnnotationList
             Annotation object instantiated from file.
         """
-        _annotation_pb2 = open_pbobject(annotation_file, KeyPoint2DAnnotations)
+        _annotation_pb2 = parse_pbobject(annotation_file, KeyPoint2DAnnotations)
         pointlist = [
             KeyPoint2D(
                 point=np.float32([ann.point.x, ann.point.y]),

--- a/dgp/annotations/key_point_3d_annotation.py
+++ b/dgp/annotations/key_point_3d_annotation.py
@@ -9,7 +9,7 @@ from dgp.proto.annotations_pb2 import (
 )
 from dgp.utils.protobuf import (
     generate_uid_from_pbobject,
-    open_pbobject,
+    parse_pbobject,
     save_pbobject_as_json,
 )
 from dgp.utils.structures.key_point_3d import KeyPoint3D
@@ -41,8 +41,8 @@ class KeyPoint3DAnnotationList(Annotation):
 
         Parameters
         ----------
-        annotation_file: str
-            Full path to annotation
+        annotation_file: str or bytes
+            Full path to annotation or bytestring
 
         ontology: KeyPointOntology
             Ontology for 3D keypoint tasks.
@@ -52,7 +52,7 @@ class KeyPoint3DAnnotationList(Annotation):
         KeyPoint3DAnnotationList
             Annotation object instantiated from file.
         """
-        _annotation_pb2 = open_pbobject(annotation_file, KeyPoint3DAnnotations)
+        _annotation_pb2 = parse_pbobject(annotation_file, KeyPoint3DAnnotations)
         pointlist = [
             KeyPoint3D(
                 point=np.float32([ann.point.x, ann.point.y, ann.point.z]),

--- a/dgp/annotations/semantic_segmentation_2d_annotation.py
+++ b/dgp/annotations/semantic_segmentation_2d_annotation.py
@@ -3,6 +3,7 @@ import os
 
 import cv2
 import numpy as np
+import io
 
 from dgp.annotations.base_annotation import Annotation
 from dgp.annotations.ontology import SemanticSegmentationOntology
@@ -38,8 +39,8 @@ class SemanticSegmentation2DAnnotation(Annotation):
 
         Parameters
         ----------
-        annotation_file: str
-            Full path to annotation
+        annotation_file: str or bytes
+            Full path to annotation or bytestring
 
         ontology: SemanticSegmentationOntology
             Ontology for semantic segmentation tasks.
@@ -49,8 +50,13 @@ class SemanticSegmentation2DAnnotation(Annotation):
         SemanticSegmentation2DAnnotation
             Annotation object instantiated from file.
         """
-        # segmentation_image = np.array(Image.open(annotation_file), dtype=np.uint8)
-        segmentation_image = cv2.imread(annotation_file, cv2.IMREAD_UNCHANGED)
+        if isinstance(annotation_file,bytes):
+            raw_bytes = io.BytesIO(annotation_file)
+            segmentation_image = cv2.imdecode(np.frombuffer(raw_bytes.getbuffer(), np.uint8), cv2.IMREAD_UNCHANGED)
+        else:
+            # segmentation_image = np.array(Image.open(annotation_file), dtype=np.uint8)
+            segmentation_image = cv2.imread(annotation_file, cv2.IMREAD_UNCHANGED)
+
         if len(segmentation_image.shape) == 3:
             # ParllelDomain used RGBA image, and uses only R-channel.
             # TODO: discuss with PD on changing this to single-channel np.uint8 image.
@@ -59,6 +65,24 @@ class SemanticSegmentation2DAnnotation(Annotation):
         not_ignore = segmentation_image != ontology.VOID_ID
         segmentation_image[not_ignore] = ontology.label_lookup[segmentation_image[not_ignore]]
         return cls(ontology, segmentation_image)
+
+    def _convert_contiguous_to_class(self):
+        """Helper function to run pre processing prior to saving
+        
+        Returns
+        -------
+        segmentation_image: np.array
+            A copy of self._segmentation_image with contiguous_id mapped back to class_id for saving
+        """
+        # Convert the segmentation image back to original class IDs
+        reverse_label_lookup = np.ones(self.ontology.VOID_ID + 1, dtype=np.uint8) * self.ontology.VOID_ID
+        for contiguous_id, class_id in self.ontology.contiguous_id_to_class_id.items():
+            reverse_label_lookup[contiguous_id] = class_id
+
+        # Create a copy and map IDs back to original set
+        segmentation_image = np.copy(self._segmentation_image)
+        not_ignore = segmentation_image != self.ontology.VOID_ID
+        segmentation_image[not_ignore] = reverse_label_lookup[segmentation_image[not_ignore]]
 
     def save(self, save_dir):
         """Serialize Annotation object and saved to specified directory. Annotations are saved in format <save_dir>/<sha>.<ext>
@@ -73,16 +97,8 @@ class SemanticSegmentation2DAnnotation(Annotation):
         output_annotation_file: str
             Full path to saved annotation
         """
-        # Convert the segmentation image back to original class IDs
-        reverse_label_lookup = np.ones(self.ontology.VOID_ID + 1, dtype=np.uint8) * self.ontology.VOID_ID
-        for contiguous_id, class_id in self.ontology.contiguous_id_to_class_id.items():
-            reverse_label_lookup[contiguous_id] = class_id
-
-        # Create a copy and map IDs back to original set
-        segmentation_image = np.copy(self._segmentation_image)
-        not_ignore = segmentation_image != self.ontology.VOID_ID
-        segmentation_image[not_ignore] = reverse_label_lookup[segmentation_image[not_ignore]]
-
+        segmentation_image = self._convert_contiguous_to_class()
+        
         # Save the image as PNG
         output_annotation_file = os.path.join(
             save_dir, f"{generate_uid_from_semantic_segmentation_2d_annotation(segmentation_image)}.png"

--- a/dgp/annotations/semantic_segmentation_2d_annotation.py
+++ b/dgp/annotations/semantic_segmentation_2d_annotation.py
@@ -83,6 +83,7 @@ class SemanticSegmentation2DAnnotation(Annotation):
         segmentation_image = np.copy(self._segmentation_image)
         not_ignore = segmentation_image != self.ontology.VOID_ID
         segmentation_image[not_ignore] = reverse_label_lookup[segmentation_image[not_ignore]]
+        return segmentation_image
 
     def save(self, save_dir):
         """Serialize Annotation object and saved to specified directory. Annotations are saved in format <save_dir>/<sha>.<ext>

--- a/dgp/annotations/semantic_segmentation_2d_annotation.py
+++ b/dgp/annotations/semantic_segmentation_2d_annotation.py
@@ -1,9 +1,9 @@
 # Copyright 2021 Toyota Research Institute.  All rights reserved.
+import io
 import os
 
 import cv2
 import numpy as np
-import io
 
 from dgp.annotations.base_annotation import Annotation
 from dgp.annotations.ontology import SemanticSegmentationOntology
@@ -50,7 +50,7 @@ class SemanticSegmentation2DAnnotation(Annotation):
         SemanticSegmentation2DAnnotation
             Annotation object instantiated from file.
         """
-        if isinstance(annotation_file,bytes):
+        if isinstance(annotation_file, bytes):
             raw_bytes = io.BytesIO(annotation_file)
             segmentation_image = cv2.imdecode(np.frombuffer(raw_bytes.getbuffer(), np.uint8), cv2.IMREAD_UNCHANGED)
         else:
@@ -99,7 +99,7 @@ class SemanticSegmentation2DAnnotation(Annotation):
             Full path to saved annotation
         """
         segmentation_image = self._convert_contiguous_to_class()
-        
+
         # Save the image as PNG
         output_annotation_file = os.path.join(
             save_dir, f"{generate_uid_from_semantic_segmentation_2d_annotation(segmentation_image)}.png"

--- a/dgp/annotations/semantic_segmentation_2d_annotation.py
+++ b/dgp/annotations/semantic_segmentation_2d_annotation.py
@@ -54,7 +54,6 @@ class SemanticSegmentation2DAnnotation(Annotation):
             raw_bytes = io.BytesIO(annotation_file)
             segmentation_image = cv2.imdecode(np.frombuffer(raw_bytes.getbuffer(), np.uint8), cv2.IMREAD_UNCHANGED)
         else:
-            # segmentation_image = np.array(Image.open(annotation_file), dtype=np.uint8)
             segmentation_image = cv2.imread(annotation_file, cv2.IMREAD_UNCHANGED)
 
         if len(segmentation_image.shape) == 3:

--- a/dgp/annotations/semantic_segmentation_2d_annotation.py
+++ b/dgp/annotations/semantic_segmentation_2d_annotation.py
@@ -68,7 +68,7 @@ class SemanticSegmentation2DAnnotation(Annotation):
 
     def _convert_contiguous_to_class(self):
         """Helper function to run pre processing prior to saving
-        
+
         Returns
         -------
         segmentation_image: np.array

--- a/dgp/contribs/dgp2wicker/Makefile
+++ b/dgp/contribs/dgp2wicker/Makefile
@@ -16,8 +16,7 @@ DOCKER_OPTS ?= \
 	-e VAULT_ASSUMED_ROLE \
 	-e WICKER_CONFIG_PATH \
 	-e DISPLAY=${DISPLAY} \
-	-v $(PWD):$(WORKSPACE) \
-	-v /home/ubuntu/dgp:/home/dgp
+	-v $(PWD):$(WORKSPACE)
 
 develop:
 	pip install --editable .

--- a/dgp/contribs/dgp2wicker/Makefile
+++ b/dgp/contribs/dgp2wicker/Makefile
@@ -16,7 +16,8 @@ DOCKER_OPTS ?= \
 	-e VAULT_ASSUMED_ROLE \
 	-e WICKER_CONFIG_PATH \
 	-e DISPLAY=${DISPLAY} \
-	-v $(PWD):$(WORKSPACE)
+	-v $(PWD):$(WORKSPACE) \
+	-v /home/ubuntu/dgp:/home/dgp
 
 develop:
 	pip install --editable .

--- a/dgp/contribs/dgp2wicker/dgp2wicker/ingest.py
+++ b/dgp/contribs/dgp2wicker/dgp2wicker/ingest.py
@@ -50,6 +50,8 @@ FIELD_TO_WICKER_SERIALIZER = {
     'covariance': ws.PointCloudSerializer,
     'key_point_2d': ws.KeyPoint2DSerializer,
     'key_line_2d': ws.KeyLine2DSerializer,
+    'key_point_3d': ws.KeyPoint3DSerializer,
+    'key_line_3d': ws.KeyLine3DSerializer,
 }
 
 logger = logging.getLogger(__name__)

--- a/dgp/contribs/dgp2wicker/dgp2wicker/ingest.py
+++ b/dgp/contribs/dgp2wicker/dgp2wicker/ingest.py
@@ -17,7 +17,6 @@ import pyspark
 import wicker
 import wicker.plugins.spark as wsp
 from wicker.schema import IntField, StringField
-#wsp.SPARK_PARTITION_SIZE = 12
 
 from dgp.datasets import ParallelDomainScene, SynchronizedScene
 from dgp.proto import dataset_pb2
@@ -570,6 +569,9 @@ def ingest_dgp_to_wicker(
     # Shuffle the scenes
     scene_shuffle_idx = np.random.permutation(len(scenes)).tolist()
     scenes = [ scenes[i] for i in scene_shuffle_idx]
+    if len(scenes) < 2:
+        wsp.SPARK_PARTITION_SIZE = 3
+
 
     # Setup spark
     if spark_context is None:

--- a/dgp/contribs/dgp2wicker/dgp2wicker/ingest.py
+++ b/dgp/contribs/dgp2wicker/dgp2wicker/ingest.py
@@ -17,7 +17,7 @@ import pyspark
 import wicker
 import wicker.plugins.spark as wsp
 from wicker.schema import IntField, StringField
-wsp.SPARK_PARTITION_SIZE = 12
+#wsp.SPARK_PARTITION_SIZE = 12
 
 from dgp.datasets import ParallelDomainScene, SynchronizedScene
 from dgp.proto import dataset_pb2
@@ -25,9 +25,9 @@ from dgp.proto.dataset_pb2 import SceneDataset
 from dgp.utils.cloud.s3 import sync_dir
 from dgp.utils.protobuf import open_pbobject
 
-ILLEGAL_COMBINATIONS = set([('point_cloud', 'depth'), ('point_cloud', 'semantic_segmentation_2d'),
-                            ('point_cloud', 'instance_segmentation_2d'), ('point_cloud', 'bounding_box_2d'), ('point_cloud','key_point_2d')])
-
+PC_DATUMS = ('point_cloud','radar_point_cloud')
+NON_PC_FIELDS = ('depth','semantic_segmentation_2d','instance_segmentation_2d','bounding_box_2d','key_point_2d','key_line_2d')
+ILLEGAL_COMBINATIONS = { (pc_datum, field) for pc_datum in PC_DATUMS for field in NON_PC_FIELDS}
 WICKER_KEY_SEPARATOR = '____'
 
 # Map keys in SynchronizedScene output to wicker serialization methods
@@ -49,6 +49,7 @@ FIELD_TO_WICKER_SERIALIZER = {
     'velocity': ws.PointCloudSerializer,
     'covariance': ws.PointCloudSerializer,
     'key_point_2d': ws.KeyPoint2DSerializer,
+    'key_line_2d': ws.KeyLine2DSerializer,
 }
 
 logger = logging.getLogger(__name__)

--- a/dgp/contribs/dgp2wicker/dgp2wicker/ingest.py
+++ b/dgp/contribs/dgp2wicker/dgp2wicker/ingest.py
@@ -24,9 +24,11 @@ from dgp.proto.dataset_pb2 import SceneDataset
 from dgp.utils.cloud.s3 import sync_dir
 from dgp.utils.protobuf import open_pbobject
 
-PC_DATUMS = ('point_cloud','radar_point_cloud')
-NON_PC_FIELDS = ('depth','semantic_segmentation_2d','instance_segmentation_2d','bounding_box_2d','key_point_2d','key_line_2d')
-ILLEGAL_COMBINATIONS = { (pc_datum, field) for pc_datum in PC_DATUMS for field in NON_PC_FIELDS}
+PC_DATUMS = ('point_cloud', 'radar_point_cloud')
+NON_PC_FIELDS = (
+    'depth', 'semantic_segmentation_2d', 'instance_segmentation_2d', 'bounding_box_2d', 'key_point_2d', 'key_line_2d'
+)
+ILLEGAL_COMBINATIONS = {(pc_datum, field) for pc_datum in PC_DATUMS for field in NON_PC_FIELDS}
 WICKER_KEY_SEPARATOR = '____'
 
 # Map keys in SynchronizedScene output to wicker serialization methods
@@ -568,10 +570,9 @@ def ingest_dgp_to_wicker(
 
     # Shuffle the scenes
     scene_shuffle_idx = np.random.permutation(len(scenes)).tolist()
-    scenes = [ scenes[i] for i in scene_shuffle_idx]
+    scenes = [scenes[i] for i in scene_shuffle_idx]
     if len(scenes) < 2:
         wsp.SPARK_PARTITION_SIZE = 3
-
 
     # Setup spark
     if spark_context is None:

--- a/dgp/contribs/dgp2wicker/dgp2wicker/serializers.py
+++ b/dgp/contribs/dgp2wicker/dgp2wicker/serializers.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
 import cv2
+from dgp.annotations import ontology
 from dgp.utils.protobuf import open_ontology_pbobject
 import numpy as np
 from PIL import Image
@@ -236,7 +237,7 @@ class SemanticSegmentation2DSerializer(WickerSerializer):
     def unserialize(self, raw: bytes) -> SemanticSegmentation2DAnnotation:
         if raw == WICKER_RAW_NONE_VALUE or self.ontology is None:
             return None
-        return SemanticSegmentation2DAnnotation(raw,self.ontology)
+        return SemanticSegmentation2DAnnotation.load(raw,self.ontology)
 
     def set_ontology(self, ontology: Ontology):
         self.ontology = ontology

--- a/dgp/contribs/dgp2wicker/dgp2wicker/serializers.py
+++ b/dgp/contribs/dgp2wicker/dgp2wicker/serializers.py
@@ -197,7 +197,7 @@ class BoundingBox3DSerializer(WickerSerializer):
     def schema(self, name: str, data: Any):
         return BytesField(name, required=False, is_heavy_pointer=True)
 
-    def serialize(self, annotation: Optional[KeyPoint2DAnnotationList]) -> bytes:
+    def serialize(self, annotation: Optional[BoundingBox3DAnnotationList]) -> bytes:
         if annotation is None:
             return WICKER_RAW_NONE_VALUE
         return annotation.to_proto().SerializeToString()

--- a/dgp/contribs/dgp2wicker/dgp2wicker/serializers.py
+++ b/dgp/contribs/dgp2wicker/dgp2wicker/serializers.py
@@ -11,8 +11,6 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
 import cv2
-from dgp.annotations import ontology
-from dgp.utils.protobuf import open_ontology_pbobject
 import numpy as np
 from PIL import Image
 from wicker.schema import BytesField, LongField, NumpyField, StringField
@@ -22,15 +20,17 @@ from dgp.annotations import (
     BoundingBox2DAnnotationList,
     BoundingBox3DAnnotationList,
     DenseDepthAnnotation,
+    KeyLine2DAnnotationList,
+    KeyLine3DAnnotationList,
+    KeyPoint2DAnnotationList,
+    KeyPoint3DAnnotationList,
     PanopticSegmentation2DAnnotation,
     SemanticSegmentation2DAnnotation,
-    KeyPoint2DAnnotationList,
-    KeyLine2DAnnotationList,
-    KeyPoint3DAnnotationList,
-    KeyLine3DAnnotationList,
+    ontology,
 )
 from dgp.annotations.ontology import Ontology
 from dgp.utils.pose import Pose
+from dgp.utils.protobuf import open_ontology_pbobject
 
 WICKER_RAW_NONE_VALUE = b'\x00\x00\x00\x00'
 
@@ -178,7 +178,7 @@ class BoundingBox2DSerializer(WickerSerializer):
         if raw == WICKER_RAW_NONE_VALUE or self.ontology is None:
             return None
 
-        return BoundingBox2DAnnotationList.load(raw,self.ontology)
+        return BoundingBox2DAnnotationList.load(raw, self.ontology)
 
 
 class BoundingBox3DSerializer(WickerSerializer):
@@ -206,7 +206,7 @@ class BoundingBox3DSerializer(WickerSerializer):
         if raw == WICKER_RAW_NONE_VALUE or self.ontology is None:
             return None
 
-        return BoundingBox3DAnnotationList.load(raw,self.ontology)
+        return BoundingBox3DAnnotationList.load(raw, self.ontology)
 
 
 class SemanticSegmentation2DSerializer(WickerSerializer):
@@ -237,7 +237,7 @@ class SemanticSegmentation2DSerializer(WickerSerializer):
     def unserialize(self, raw: bytes) -> SemanticSegmentation2DAnnotation:
         if raw == WICKER_RAW_NONE_VALUE or self.ontology is None:
             return None
-        return SemanticSegmentation2DAnnotation.load(raw,self.ontology)
+        return SemanticSegmentation2DAnnotation.load(raw, self.ontology)
 
     def set_ontology(self, ontology: Ontology):
         self.ontology = ontology
@@ -345,7 +345,7 @@ class KeyPoint2DSerializer(WickerSerializer):
         if raw == WICKER_RAW_NONE_VALUE or self.ontology is None:
             return None
 
-        return KeyPoint2DAnnotationList.load(raw,self.ontology)
+        return KeyPoint2DAnnotationList.load(raw, self.ontology)
 
 
 class KeyLine2DSerializer(WickerSerializer):
@@ -373,7 +373,8 @@ class KeyLine2DSerializer(WickerSerializer):
         if raw == WICKER_RAW_NONE_VALUE or self.ontology is None:
             return None
 
-        return KeyLine2DAnnotationList.load(raw,self.ontology)
+        return KeyLine2DAnnotationList.load(raw, self.ontology)
+
 
 class KeyPoint3DSerializer(WickerSerializer):
     def __init__(self, ):
@@ -400,7 +401,7 @@ class KeyPoint3DSerializer(WickerSerializer):
         if raw == WICKER_RAW_NONE_VALUE or self.ontology is None:
             return None
 
-        return KeyPoint3DAnnotationList.load(raw,self.ontology)
+        return KeyPoint3DAnnotationList.load(raw, self.ontology)
 
 
 class KeyLine3DSerializer(WickerSerializer):
@@ -428,4 +429,4 @@ class KeyLine3DSerializer(WickerSerializer):
         if raw == WICKER_RAW_NONE_VALUE or self.ontology is None:
             return None
 
-        return KeyLine3DAnnotationList.load(raw,self.ontology)
+        return KeyLine3DAnnotationList.load(raw, self.ontology)

--- a/dgp/contribs/dgp2wicker/dgp2wicker/serializers.py
+++ b/dgp/contribs/dgp2wicker/dgp2wicker/serializers.py
@@ -202,7 +202,7 @@ class BoundingBox3DSerializer(WickerSerializer):
             return WICKER_RAW_NONE_VALUE
         return annotation.to_proto().SerializeToString()
 
-    def unserialize(self, raw: bytes) -> KeyPoint2DAnnotationList:
+    def unserialize(self, raw: bytes) -> BoundingBox3DAnnotationList:
         if raw == WICKER_RAW_NONE_VALUE or self.ontology is None:
             return None
 

--- a/dgp/datasets/base_dataset.py
+++ b/dgp/datasets/base_dataset.py
@@ -265,9 +265,18 @@ class SceneContainer:
             filename = scene.ontology_files['bounding_box_2d']
         """
         # Load ontology files.
+
+        # Note: When loading some experimental datasets from other sources such as Parallel Domain
+        # It is possible to have annotation types that are not supported. For now we will throw
+        # a warning and move on.
+        # TODO: work with PD to have consistent protos
+        for ann_id in self.scene.ontologies:
+            if ann_id not in ANNOTATION_TYPE_ID_TO_KEY:
+                logging.warning(f'Found annotation type id {ann_id} however only the following ids are allowed {set(ANNOTATION_TYPE_ID_TO_KEY.keys())} are defined. Skipping...' )
+
         ontology_files = {
             ANNOTATION_TYPE_ID_TO_KEY[ann_id]: os.path.join(self.directory, ONTOLOGY_FOLDER, "{}.json".format(f))
-            for ann_id, f in self.scene.ontologies.items()
+            for ann_id, f in self.scene.ontologies.items() if ann_id in ANNOTATION_TYPE_ID_TO_KEY
         }
 
         # Load autolabeled items in the scene.

--- a/dgp/datasets/base_dataset.py
+++ b/dgp/datasets/base_dataset.py
@@ -272,11 +272,14 @@ class SceneContainer:
         # TODO: work with PD to have consistent protos
         for ann_id in self.scene.ontologies:
             if ann_id not in ANNOTATION_TYPE_ID_TO_KEY:
-                logging.warning(f'Found annotation type id {ann_id} however only the following ids are allowed {set(ANNOTATION_TYPE_ID_TO_KEY.keys())} are defined. Skipping...' )
+                logging.warning(
+                    f'Found annotation type id {ann_id} however only the following ids are allowed {set(ANNOTATION_TYPE_ID_TO_KEY.keys())} are defined. Skipping...'
+                )
 
         ontology_files = {
             ANNOTATION_TYPE_ID_TO_KEY[ann_id]: os.path.join(self.directory, ONTOLOGY_FOLDER, "{}.json".format(f))
-            for ann_id, f in self.scene.ontologies.items() if ann_id in ANNOTATION_TYPE_ID_TO_KEY
+            for ann_id, f in self.scene.ontologies.items()
+            if ann_id in ANNOTATION_TYPE_ID_TO_KEY
         }
 
         # Load autolabeled items in the scene.

--- a/dgp/utils/protobuf.py
+++ b/dgp/utils/protobuf.py
@@ -44,6 +44,7 @@ def open_pbobject(path, pb_class):
         pb_object = Parse(json_file.read(), pb_class())
     return pb_object
 
+
 def parse_pbobject(source, pb_class):
     """Like open_pboject but source can be a path or a bytestring
     
@@ -159,7 +160,7 @@ def open_ontology_pbobject(ontology_file):
             logging.info('Successfully loaded Ontology V1 spec.')
             return ontology
     except Exception:
-        if isinstance(ontology_file,str):
+        if isinstance(ontology_file, str):
             logging.error('Failed to load ontology file' + ontology_file + 'with V1 spec also, returning None.')
         else:
             logging.error('Failed to load ontology file with V1 spec also, returning None.')

--- a/dgp/utils/protobuf.py
+++ b/dgp/utils/protobuf.py
@@ -53,7 +53,11 @@ def parse_pbobject(source, pb_class):
     source: str or bytes
         Local JSON file path, remote s3 path to object, or bytestring of serialized object
     
+    pb_class: object
+        Protobuf pb2 object we want to load into.
+
     Returns
+    -------
     pb_object: pb2 object or None
         Desired pb2 ojbect to be parsed or None if loading fails
     """

--- a/dgp/utils/protobuf.py
+++ b/dgp/utils/protobuf.py
@@ -47,12 +47,12 @@ def open_pbobject(path, pb_class):
 
 def parse_pbobject(source, pb_class):
     """Like open_pboject but source can be a path or a bytestring
-    
+
     Parameters
     ----------
     source: str or bytes
         Local JSON file path, remote s3 path to object, or bytestring of serialized object
-    
+
     pb_class: object
         Protobuf pb2 object we want to load into.
 


### PR DESCRIPTION

- Adds support in dgp2wicker for key_point_2d, key_line_2d, key_point_3d, and key_line_3d
- Adds key_point_2d and key_line_3d support to SynchronizedScene 
- Fixes bug in dgp2wicker semantic segmentation 2d
- Removes duplicate code for most dgp2wicker serializers by switching open_pbobject to overloaded version parse_pbobject which can operate on bytes
- Skips unknown annotation types sometimes found in PD datasets in base_dataset
- Adds support for ontology V1 in dgp2wicker
- Fixes bug in dgp2wicker radar_point_cloud 2d annotation type handling

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/dgp/142)
<!-- Reviewable:end -->
