### PR TITLE
build: fix missing protobuf dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ boto3
 botocore
 Click>=7.1.2
 diskcache>=4.1.0
+protobuf==3.20.1
 matplotlib>=3.0.3,<4.0
 opencv-python>=4.5.3.56
 Pillow>=8.3.2


### PR DESCRIPTION
After installation, some missing dependency prevents the use of protobuf

```
Traceback (most recent call last):
  File "/Users/chunleng.lim/Documents/git/dgp/test.py", line 1, in <module>
    from dgp.annotations import semantic_segmentation_2d_annotation
  File "/Users/chunleng.lim/Documents/git/dgp/dgp/annotations/__init__.py", line 5, in <module>
    from dgp.annotations.ontology import (
  File "/Users/chunleng.lim/Documents/git/dgp/dgp/annotations/ontology.py", line 7, in <module>
    from dgp.proto.dataset_pb2 import Ontology as OntologyV1Pb2
  File "/Users/chunleng.lim/Documents/git/dgp/dgp/proto/dataset_pb2.py", line 5, in <module>
    from google.protobuf.internal import enum_type_wrapper
ModuleNotFoundError: No module named 'google.protobuf'
```