### PR TITLE
fix: fix point cloud shape

### DIFF
--- a/dgp/datasets/base_dataset.py
+++ b/dgp/datasets/base_dataset.py
@@ -1420,7 +1420,9 @@ class BaseDataset:
                 # TODO: Expose all point fields.
                 # fields = datum.datum.point_cloud.point_format
                 # PointCloudPb2.ChannelType.DESCRIPTOR.values_by_name['X'].number
-                X = np.hstack([X['X'], X['Y'], X['Z'], X['INTENSITY']])
+                X = np.hstack([
+                    X['X'].reshape(-1, 1), X['Y'].reshape(-1, 1), X['Z'].reshape(-1, 1), X['INTENSITY'].reshape(-1, 1)
+                ])
             return X
         elif datum.datum.HasField('file_datum'):
             return datum.datum.file_datum.datum.filename


### PR DESCRIPTION
Some parallel domain datasets are using (n,) for the point cloud shapes, this removes the implicit assumption that that all point cloud fields are (n,1).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TRI-ML/dgp/153)
<!-- Reviewable:end -->
