### PR TITLE
docs: fix contributing guidelines

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,7 +14,7 @@ GitWorkflow.
 4. Enable githooks (linting, autoformatting) via:
 
 ```sh
-dgp$ make link-githooks
+dgp$ make setup-linters
 ```
 
 ## Getting started
@@ -100,7 +100,7 @@ DGP runs `isort` and `yapf` to autoformat the files in pre-commit, and perform
 additional linting using `pylint` in pre-push. One can enable githooks via:
 
 ```sh
-dgp$ make link-githooks
+dgp$ make setup-linters
 ```
 
 ### Making a pull request


### PR DESCRIPTION
It seems that Makefile target `link-githooks` no longer exists and now it is called `setup-linters`

Update docs accordingly

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TRI-ML/dgp/154)
<!-- Reviewable:end -->
