### PR TITLE
build: switch to pillow simd by default

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ diskcache>=4.1.0
 protobuf>=3.20.1,<4.0.0
 matplotlib>=3.0.3,<4.0
 opencv-python>=4.5.3.56
-Pillow>=8.3.2
+Pillow-SIMD>=8.3.2
 pycocotools>=2.0.0
 pyquaternion>=0.9.5,<=1.0.0
 torch>=1.8.1


### PR DESCRIPTION
Switches from Pillow to Pillow-simd in requirements.

Pillow-simd was being used in the docker but Pillow was listed in the reqs. The docker version is installed with avx2 support.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TRI-ML/dgp/162)
<!-- Reviewable:end -->
