### PR TITLE
fix: fix conversion in key point and keyline 3d

### DIFF
--- a/dgp/utils/structures/key_line_3d.py
+++ b/dgp/utils/structures/key_line_3d.py
@@ -95,6 +95,6 @@ class KeyLine3D:
             As defined in `proto/annotations.proto`
         """
         return [
-            annotations_pb2.KeyPoint3D(x=int(self.x[j]), y=int(self.y[j]), z=int(self.z[j]))
+            annotations_pb2.KeyPoint3D(x=float(self.x[j]), y=float(self.y[j]), z=float(self.z[j]))
             for j, _ in enumerate(self.x)
         ]

--- a/dgp/utils/structures/key_point_3d.py
+++ b/dgp/utils/structures/key_point_3d.py
@@ -91,4 +91,4 @@ class KeyPoint3D:
         KeyPoint3D.pb2
             As defined in `proto/annotations.proto`
         """
-        return annotations_pb2.KeyPoint3D(x=int(self.x), y=int(self.y), z=int(self.z))
+        return annotations_pb2.KeyPoint3D(x=float(self.x), y=float(self.y), z=float(self.z))

--- a/tests/annotation/test_key_line_3d_annotation.py
+++ b/tests/annotation/test_key_line_3d_annotation.py
@@ -35,7 +35,7 @@ def test_kl3d_annotation(kl_ontology):
 
 def test_kl3d_load(kl_ontology):
     DGP_TEST_DATASET_DIR = os.path.join(TEST_DATA_DIR, "dgp")
-    expected_output = "ac354"
+    expected_output = "a28b1"
     scenes_dataset_json = os.path.join(
         DGP_TEST_DATASET_DIR,
         "key_line_3d/scene_000000/key_line_3d/lcm_25tm/000000000000000005_21e2436af96fb6388eb0c64cc029cfdc928a3e95.json"
@@ -63,6 +63,6 @@ def test_kl3d_save(kl_ontology):
     )
     kl3d_list = KeyLine3DAnnotationList.load(scenes_dataset_json, kl_ontology)
     kl3d_list.save(".")
-    filepath = "./ac35449091ebdd374aaa743be74794db561ec86a.json"
+    filepath = "./a28b1cd7793c14d5ddae40d6a2065576f9856976.json"
     assert os.path.exists(filepath)
     os.remove(filepath)


### PR DESCRIPTION
Keypoint and keyline 3d were being converted to integers on saving, the proto definition expects floats. This leads to loss of precision on saving.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TRI-ML/dgp/167)
<!-- Reviewable:end -->
