### PR TITLE
Remove tk-woven from default assignees

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: "Bug Report"
 about: Submit a bug report to help us improve DGP
-assignees: chrisochoatri, kuanleetri, ryo-takahashi-1206, tk-woven, wadimkehl, ykkawana-woven
+assignees: chrisochoatri, kuanleetri, ryo-takahashi-1206, wadimkehl, ykkawana-woven
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: "Feature Request"
 about: Submit a proposal/request for a new feature in DGP
-assignees: chrisochoatri, kuanleetri, ryo-takahashi-1206, tk-woven, wadimkehl, ykkawana-woven
+assignees: chrisochoatri, kuanleetri, ryo-takahashi-1206, wadimkehl, ykkawana-woven
 
 ---
 


### PR DESCRIPTION
I am no longer working on anything related to DGP, and I never was a core designer or maintainer (only a maintainer to help unblock some Woven-internal things). So, I am removing myself as a default assignee on issue templates.