### PR TITLE
chore: bump version to 2.2.0 and modernize build infrastructure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,22 +2,20 @@
 # See https://pre-commit.com/hooks.html for more hooks
 
 default_language_version:
-  python: python3
-  # Node 18+ requires GLIBC 2.18 which is only available by default in
-  # Ubuntu 18.10+. Fix to Node 17 while we still use Ubuntu 18.04.
-  node: 17.0.0
+  python: python3.10
+  node: 20.0.0
 
-default_stages: [commit]
+default_stages: [pre-commit]
 
 repos:
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.0.0
+    rev: v9.22.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v6.0.0
     hooks:
       - id: check-json
   - repo: https://github.com/zricethezav/gitleaks

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM nvidia/cuda:11.6.1-cudnn8-devel-ubuntu20.04
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
 
-ARG python=3.9
-ENV PYTORCH_VERSION=1.13.1+cu116
-ENV TORCHVISION_VERSION=0.14.1+cu116
+ARG python=3.10
+ENV PYTORCH_VERSION=2.3.1+cu118
+ENV TORCHVISION_VERSION=0.18.1+cu118
+ENV CUDA_VERSION_SHORT=cu118
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
@@ -12,10 +13,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Set default shell to /bin/bash
 SHELL ["/bin/bash", "-cu"]
-
-# Temporary fix for invalid GPG key see
-# https://forums.developer.nvidia.com/t/gpg-error-http-developer-download-nvidia-com-compute-cuda-repos-ubuntu1804-x86-64/212904
-RUN apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 
 RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-packages --no-install-recommends \
   build-essential \
@@ -40,15 +37,13 @@ RUN ln -sf /usr/local/bin/pip3 /usr/bin/pip3
 RUN pip install --no-cache-dir \
   torch==${PYTORCH_VERSION} \
   torchvision==${TORCHVISION_VERSION} \
-  -f https://download.pytorch.org/whl/${PYTORCH_VERSION/*+/}/torch_stable.html
+  -f https://download.pytorch.org/whl/${CUDA_VERSION_SHORT}/torch_stable.html
 
 
 # Install python dependencies
 ARG WORKSPACE=/home/dgp
 WORKDIR ${WORKSPACE}
 COPY requirements.txt requirements-dev.txt /tmp/
-# Install torch-compatible NumPy.
-RUN pip install numpy==1.26.4
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements-dev.txt
 
@@ -58,4 +53,4 @@ RUN aws configure set default.s3.max_concurrent_requests 100 && \
 
 # Copy workspace and setup PYTHONPATH
 COPY . ${WORKSPACE}
-ENV PYTHONPATH="${WORKSPACE}:$PYTHONPATH"
+ENV PYTHONPATH="${WORKSPACE}"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Copyright 2019-2021 Toyota Research Institute.  All rights reserved.
-PYTHON_EXEC ?= python3
+PYTHON_EXEC ?= python3.10
 PACKAGE_NAME ?= dgp
 WORKSPACE ?= /home/$(PACKAGE_NAME)
 DOCKER_IMAGE_NAME ?= $(PACKAGE_NAME)
@@ -42,8 +42,7 @@ all: clean test
 
 
 build:
-	PYTHONPATH=$(PWD):$(PYTHONPATH) \
-	DGP_DEV_VERSION=$(DEV_VERSION) $(PYTHON_EXEC) setup.py bdist_wheel
+	DGP_DEV_VERSION=$(DEV_VERSION) uv build --wheel
 
 clean:
 	rm -rf build dist && \

--- a/dgp/__init__.py
+++ b/dgp/__init__.py
@@ -1,7 +1,7 @@
 # Copyright 2021-2022 Toyota Research Institute. All rights reserved.
 import os
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 DGP_PATH = os.getenv("DGP_PATH", default=os.getenv("HOME", os.getcwd()))
 DGP_DATA_DIR = os.path.join(DGP_PATH, ".dgp")

--- a/dgp/contribs/pd/metadata_pb2_grpc.py
+++ b/dgp/contribs/pd/metadata_pb2_grpc.py
@@ -4,7 +4,7 @@ import warnings
 
 import grpc
 
-GRPC_GENERATED_VERSION = '1.78.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/dgp/utils/colors.py
+++ b/dgp/utils/colors.py
@@ -36,7 +36,7 @@ def get_unique_colors(num_colors, in_bgr=False, cmap='tab20'):
     List[Tuple[int]]
         List of colors in 3-tuple.
     """
-    colors = list(matplotlib.cm.get_cmap(cmap).colors)[:num_colors]
+    colors = list(matplotlib.colormaps[cmap].colors)[:num_colors]
 
     if in_bgr:
         colors = [(clr[2], clr[1], clr[0]) for clr in colors]

--- a/dgp/utils/visualization_engine.py
+++ b/dgp/utils/visualization_engine.py
@@ -3,8 +3,8 @@ import logging
 import os
 
 import cv2
+import matplotlib
 import numpy as np
-from matplotlib.cm import get_cmap
 
 from dgp.utils.colors import (
     WHITE,
@@ -20,7 +20,7 @@ from dgp.utils.visualization_utils import (
     visualize_semantic_segmentation_2d,
 )
 
-MPL_JET_CMAP = get_cmap('jet')
+MPL_JET_CMAP = matplotlib.colormaps['jet']
 
 LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.INFO)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,12 @@
+[build-system]
+requires = [
+    "setuptools>=61",
+    "wheel",
+    "grpcio>=1.80.0",
+    "grpcio-tools>=1.80.0",
+]
+build-backend = "setuptools.build_meta"
+
 [tool.isort]
 # Configure isort to play nicely with our YAPF configuration.
 # https://pycqa.github.io/isort/docs/configuration/multi_line_output_modes.html#3-vertical-hanging-indent

--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,7 @@ with open("requirements-dev.txt", encoding="utf-8") as f:
     requirements_dev = f.read().splitlines()
 
 install_requires = requirements + [
-    "protobuf>=6.30.1",
-]
-setup_requires = [
-    "protobuf>=6.30.1",
-    "grpcio>=1.70.0",
-    "grpcio-tools>=1.70.0",
+    "protobuf>=6.30.1,<7.0.0",
 ]
 
 
@@ -85,7 +80,6 @@ setup(
     },
     include_package_data=True,
     install_requires=install_requires,
-    setup_requires=setup_requires,
     extras_require={
         "dev": requirements_dev,
     },


### PR DESCRIPTION
### Summary
* Bumps dgp version to `2.2.0`
* Upgrades base Docker image from `nvidia/cuda:11.6.1-cudnn8-devel-ubuntu20.04` to `nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04`, enabling Python 3.10 from standard repos (no PPA required)
* Bumps PyTorch to `2.3.1+cu118` and torchvision to `0.18.1+cu118`, adding NumPy 2.0 compatibility
* Pins `protobuf>=6.30.1,<7.0.0` to stay within `grpcio-tools` supported range; bumps `grpcio`/`grpcio-tools` to `>=1.80.0`
* Replaces legacy `setup.py bdist_wheel build` with `uv build --wheel` — self-contained, no build package required
* Adds `[build-system]` table to `pyproject.toml` (PEP 517); removes now-redundant `setup_requires` from `setup.py`
* Fixes `matplotlib` deprecation warnings in `visualization_engine.py` and `colors.py` (`get_cmap` → `colormaps[]`)
* Bumps pre-commit hooks: `commitlint-pre-commit-hook` v9.0.0 → v9.22.0, pins default Python to 3.10 and Node to 20.0.0